### PR TITLE
Metafilter bool to str

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.4
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.3
+  VERSION: 0.1.4
   IMAGE_NAME: cpg-flow-lrs-annotation
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version='0.1.0'
+version='0.1.4'
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',

--- a/src/lrs_annotation/inputs.py
+++ b/src/lrs_annotation/inputs.py
@@ -152,7 +152,7 @@ def query_for_lrs_vcfs(
         'variant_type': {'in_': variant_types} if variant_types else None,
         'caller': {'in_': variant_callers} if variant_callers else None,
         'pipeface_version': {'in_': pipeface_versions} if pipeface_versions else None,
-        'joint_called': {'eq': False},
+        'joint_called': {'eq': 'false'},
     }
     single_sample_vcfs_query_results = query(
         VCF_QUERY,
@@ -188,7 +188,7 @@ def query_for_lrs_vcfs(
             f' analysis types: {analysis_types}, callers: {variant_callers}, pipeface versions: {pipeface_versions}',
         )
     joint_called_vcfs: dict[str, dict] = {}
-    meta_filter['joint_called'] = {'eq': True}
+    meta_filter['joint_called'] = {'eq': 'true'}
     joint_called_vcfs_query_results = query(
         VCF_QUERY,
         variables={


### PR DESCRIPTION
This totally surprised me - to filter on boolean fields with a GraphQL meta JSON filter, the boolean needs to be a string. Otherwise, it silently doesn't work 🫠 