### PR TITLE
Fix dataset sgids

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.6
+current_version = 0.1.7
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.6
+  VERSION: 0.1.7
   IMAGE_NAME: cpg-flow-lrs-annotation
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version='0.1.6'
+version='0.1.7'
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',

--- a/src/lrs_annotation/svs_annotation_stages.py
+++ b/src/lrs_annotation/svs_annotation_stages.py
@@ -364,7 +364,7 @@ class SubsetSVsMtToDatasetWithHail(stage.DatasetStage):
 
         jobs = annotate_dataset_jobs_sv(
             mt_path=mt_path,
-            sg_ids=get_sgs_from_datasets([dataset.name]),
+            sg_ids=dataset.get_sequencing_group_ids(),
             out_mt_path=outputs['mt'],
             tmp_prefix=checkpoint_prefix,
             job_attrs=self.get_job_attrs(dataset),


### PR DESCRIPTION
One more hotfix

- Get the sequencing groups in the multicohort dataset via the standard implementation, not via the filtered Metamist query implemented for getting VCFs for this pipeline. 