### PR TITLE
Fix GQ header type in jasmine merged SV VCFs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.7
+current_version = 0.1.8
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.7
+  VERSION: 0.1.8
   IMAGE_NAME: cpg-flow-lrs-annotation
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version='0.1.7'
+version='0.1.8'
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',

--- a/src/lrs_annotation/scripts/svs/sniffles_vcf_modifier.py
+++ b/src/lrs_annotation/scripts/svs/sniffles_vcf_modifier.py
@@ -134,6 +134,7 @@ def modify_sniffles_vcf(file_in: str, file_out: str, fa: str, sex_mapping_file: 
                 # Fix the GQ type, as Jasmine merged SV VCFs have GQ as a string when it should be an integer
                 if '##FORMAT=<ID=GQ,Number=1,Type=String' in line:
                     f_out.write('##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="The genotype quality">\n')
+                    continue
                 if 'CHROM' in line:
                     # Find the sample IDs in the header line to match to the input sex values
                     l_split = line.rstrip().split('\t')

--- a/src/lrs_annotation/scripts/svs/sniffles_vcf_modifier.py
+++ b/src/lrs_annotation/scripts/svs/sniffles_vcf_modifier.py
@@ -131,7 +131,9 @@ def modify_sniffles_vcf(file_in: str, file_out: str, fa: str, sex_mapping_file: 
             if line.startswith('#'):
                 if 'FORMAT=<ID=GT' in line:
                     f_out.write('##FORMAT=<ID=RD_CN,Number=1,Type=Integer,Description="Copy number of this variant">\n')
-
+                # Fix the GQ type, as Jasmine merged SV VCFs have GQ as a string when it should be an integer
+                if '##FORMAT=<ID=GQ,Number=1,Type=String' in line:
+                    f_out.write('##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="The genotype quality">\n')
                 if 'CHROM' in line:
                     # Find the sample IDs in the header line to match to the input sex values
                     l_split = line.rstrip().split('\t')


### PR DESCRIPTION
# Purpose

  - Jasmine merged SV VCFs rewrite the header line for `GQ` as type = String. This should only ever be type = Integer, this fixes the line in the header during the sniffles vcf modifying script.
