### PR TITLE
Add resource override config option for SplitVcf job

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.14
+  VERSION: 0.1.15
   IMAGE_NAME: cpg-flow-lrs-annotation
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPG-Flow - Long Read Sequencing Annotation for seqr
 
-Version 0.1.14
+Version 0.1.15
 
 A CPG workflow for creating annotated callsets from long read data, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.1.14"
+version="0.1.15"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -117,7 +117,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/lrs_annotation/bam_to_cram_stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.14"
+current_version = "0.1.15"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/lrs_annotation/jobs/snps_indels/SplitMergedVcfAndGetSitesOnlyForVep.py
+++ b/src/lrs_annotation/jobs/snps_indels/SplitMergedVcfAndGetSitesOnlyForVep.py
@@ -121,11 +121,11 @@ def add_split_vcf_job(
     j = b.new_job('SplitVcf', (job_attrs or {}) | {'tool': 'gatk SelectVariants'})
     j.image(config_retrieve(['images', 'gatk']))
     j = get_resource_overrides_for_job(j, 'split_vcf')
-    resources = config_retrieve(['workflow', 'resource_overrides', 'split_vcf'])
-    if resources['memory'] == 'highmem':
-        res = HIGHMEM.set_resources(j=j, ncpu=resources.get('cpu_cores', 1))
+    resources = config_retrieve(['workflow', 'resource_overrides', 'split_vcf'], {})
+    if resources.get('memory', 'standard') == 'highmem':
+        res = HIGHMEM.set_resources(j=j, ncpu=resources.get('cpu_cores', 2))
     else:
-        res = STANDARD.set_resources(j=j, ncpu=resources.get('cpu_cores', 1))
+        res = STANDARD.set_resources(j=j, ncpu=resources.get('cpu_cores', 2))
 
     for idx, interval in enumerate(intervals):
         output_vcf_path = output_vcf_paths[idx]

--- a/src/lrs_annotation/snps_indels_annotation.toml
+++ b/src/lrs_annotation/snps_indels_annotation.toml
@@ -20,6 +20,12 @@ cpu_cores = 4
 memory_gib = '16Gi'
 storage_gib = '50Gi'
 
+[workflow.resource_overrides.split_vcf]
+cpu_cores = 2
+memory_gib = '4Gi'
+storage_gib = '50Gi'
+
+
 [workflow.resource_overrides.export_mt_to_elastic]
 cpu_cores = 4
 memory = 'lowmem'


### PR DESCRIPTION
# Purpose

  - Add resource config overrides for the SplitVcf job. Required as the callsets get bigger and need more disk. 
  - See: https://batch.hail.populationgenomics.org.au/batches/1121007/jobs/3
