### PR TITLE
Customise dataset outputs

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.15
+  VERSION: 0.1.16
   IMAGE_NAME: cpg-flow-lrs-annotation
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPG-Flow - Long Read Sequencing Annotation for seqr
 
-Version 0.1.15
+Version 0.1.16
 
 A CPG workflow for creating annotated callsets from long read data, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.1.15"
+version="0.1.16"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -117,7 +117,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/lrs_annotation/bam_to_cram_stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.15"
+current_version = "0.1.16"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/lrs_annotation/lrs_annotation.toml
+++ b/src/lrs_annotation/lrs_annotation.toml
@@ -15,6 +15,9 @@ sequencing_type = 'genome'
 
 ref_fasta = 'gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
 
+write_mt_for_datasets = []
+create_es_index_for_datasets = []
+
 # Options for filtering Metamist queries for sequencing groups and their analysis
 [workflow.query_filters]
 # sequencing_types = [ 'genome', 'adaptive_sampling', ]

--- a/src/lrs_annotation/lrs_annotation.toml
+++ b/src/lrs_annotation/lrs_annotation.toml
@@ -15,8 +15,9 @@ sequencing_type = 'genome'
 
 ref_fasta = 'gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
 
-write_mt_for_datasets = []
-create_es_index_for_datasets = []
+# uncomment these and add dataset names to run these stages only for specific datasets
+# write_mt_for_datasets = []
+# create_es_index_for_datasets = []
 
 # Options for filtering Metamist queries for sequencing groups and their analysis
 [workflow.query_filters]

--- a/src/lrs_annotation/snps_indels_annotation_stages.py
+++ b/src/lrs_annotation/snps_indels_annotation_stages.py
@@ -328,6 +328,11 @@ class SubsetMtToDatasetWithHail(stage.DatasetStage):
             dataset (Dataset): SGIDs specific to this dataset/project
             inputs ():
         """
+        eligible_datasets = config_retrieve(['workflow', 'write_mt_for_datasets'], default=[])
+        if dataset.name not in eligible_datasets:
+            logger.info(f'Skipping MT writing for {dataset}')
+            return self.make_outputs(dataset)
+
         mt_path = inputs.as_path(target=get_multicohort(), stage=AnnotateCohortMtFromVcfWithHail, key='mt')
 
         outputs = self.expected_outputs(dataset)
@@ -373,7 +378,11 @@ class ExportSnpsIndelsMtToESIndex(stage.DatasetStage):
         """
         Uses the non-DataProc MT-to-ES conversion script
         """
-
+        # only create the elasticsearch index for the datasets specified in the config
+        eligible_datasets = config_retrieve(['workflow', 'create_es_index_for_datasets'], default=[])
+        if dataset.name not in eligible_datasets:
+            logger.info(f'Skipping ES index creation for {dataset}')
+            return None
         # try to generate a password here - we'll find out inside the script anyway, but
         # by that point we'd already have localised the MT, wasting time and money
         try:

--- a/src/lrs_annotation/snps_indels_annotation_stages.py
+++ b/src/lrs_annotation/snps_indels_annotation_stages.py
@@ -328,8 +328,10 @@ class SubsetMtToDatasetWithHail(stage.DatasetStage):
             dataset (Dataset): SGIDs specific to this dataset/project
             inputs ():
         """
-        eligible_datasets = config_retrieve(['workflow', 'write_mt_for_datasets'], default=[])
-        if dataset.name not in eligible_datasets:
+        # only create matrixtables for datasets specified in the config
+        # or, if this config option is not set, run for all datasets
+        eligible_datasets = config_retrieve(['workflow', 'write_mt_for_datasets'], default=None)
+        if eligible_datasets is not None and dataset.name not in eligible_datasets:
             logger.info(f'Skipping MT writing for {dataset}')
             return self.make_outputs(dataset)
 
@@ -379,8 +381,9 @@ class ExportSnpsIndelsMtToESIndex(stage.DatasetStage):
         Uses the non-DataProc MT-to-ES conversion script
         """
         # only create the elasticsearch index for the datasets specified in the config
-        eligible_datasets = config_retrieve(['workflow', 'create_es_index_for_datasets'], default=[])
-        if dataset.name not in eligible_datasets:
+        # or, if this config option is not set, create it for all datasets
+        eligible_datasets = config_retrieve(['workflow', 'create_es_index_for_datasets'], default=None)
+        if eligible_datasets is not None and dataset.name not in eligible_datasets:
             logger.info(f'Skipping ES index creation for {dataset}')
             return None
         # try to generate a password here - we'll find out inside the script anyway, but


### PR DESCRIPTION
# Purpose

  - To only export new matrixtables and es-indexes for datasets specified in the config
  - Useful for when some exports succeed but others fail and need to be rerun - we usually only want to rerun for the failing datasets

## Proposed Changes

  - Adds a config option just like `cpg-flow-seqr-loader` uses [here](https://github.com/populationgenomics/cpg-flow-seqr-loader/blob/main/src/cpg_seqr_loader/stages.py#L547).
 