### PR TITLE
Export es-index for specific families

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.16
+  VERSION: 0.1.17
   IMAGE_NAME: cpg-flow-lrs-annotation
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPG-Flow - Long Read Sequencing Annotation for seqr
 
-Version 0.1.16
+Version 0.1.17
 
 A CPG workflow for creating annotated callsets from long read data, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.1.16"
+version="0.1.17"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -117,7 +117,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/lrs_annotation/bam_to_cram_stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.16"
+current_version = "0.1.17"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/lrs_annotation/jobs/snps_indels/AnnotateDatasetMatrixtable.py
+++ b/src/lrs_annotation/jobs/snps_indels/AnnotateDatasetMatrixtable.py
@@ -20,10 +20,11 @@ def annotate_dataset_jobs(
     Split mt by dataset and annotate dataset-specific fields (only for those datasets
     that will be loaded into Seqr).
     """
-    sample_ids_list_path = tmp_prefix / 'sample-list.txt'
-    if not config_retrieve(['workflow', 'dry_run'], default=False):
-        with sample_ids_list_path.open('w') as f:
-            f.write(','.join(sg_ids))
+    id_file = tmp_prefix / 'sg-list.txt'
+    if not config_retrieve(['workflow', 'dry_run'], False):
+        with id_file.open('w') as f:
+            for sg_id in sorted(sg_ids):
+                f.write(f'{sg_id}\n')
 
     subset_mt_path = tmp_prefix / 'cohort-subset.mt'
 

--- a/src/lrs_annotation/snps_indels_annotation.toml
+++ b/src/lrs_annotation/snps_indels_annotation.toml
@@ -10,6 +10,10 @@ name = 'snps_indels_annotation'
 # prefer_joint_called = false
 # parental_id_suffixes = [ '01', '02', ]
 
+# Use this option to export mt / es-index for only certain families in a dataset
+# [workflow.dataset_name]
+# only_families = []
+
 [workflow.resource_overrides.reformat_snps_indels_vcf]
 cpu_cores = 1
 memory_gib = '4Gi'


### PR DESCRIPTION
# Purpose

  - Re-implement the dataset mt subsetting / ES Index export for families specified in the config
  - This allows partial index exports, instead of forcing for the whole dataset

Lifted directly from cpg-flow-seqr-loader:
https://github.com/populationgenomics/cpg-flow-seqr-loader/blob/main/src/cpg_seqr_loader/utils.py#L246

Helps prevent failures that occur when exporting very large indexes, e.g.

- https://batch.hail.populationgenomics.org.au/batches/1121471/jobs/1
- https://batch.hail.populationgenomics.org.au/batches/1121501/jobs/1