### PR TITLE
Non preemptible esindex vms

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.17
+  VERSION: 0.1.18
   IMAGE_NAME: cpg-flow-lrs-annotation
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPG-Flow - Long Read Sequencing Annotation for seqr
 
-Version 0.1.17
+Version 0.1.18
 
 A CPG workflow for creating annotated callsets from long read data, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.1.17"
+version="0.1.18"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -117,7 +117,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/lrs_annotation/bam_to_cram_stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.17"
+current_version = "0.1.18"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/lrs_annotation/jobs/ExportMtToElasticsearch.py
+++ b/src/lrs_annotation/jobs/ExportMtToElasticsearch.py
@@ -19,6 +19,7 @@ def export_mt_to_elasticsearch(
     es_export_job = batch.new_job(job_name, attributes=job_attrs)
     es_export_job.image(config_retrieve(['workflow', 'driver_image']))
     es_export_job.storage(f'{req_storage}Gi')
+    es_export_job.spot(is_spot=config_retrieve(['elasticsearch', 'spot_instance'], default=True))
     es_export_job = get_resource_overrides_for_job(es_export_job, 'export_mt_to_elasticsearch')
 
     # localise the MT

--- a/src/lrs_annotation/lrs_annotation.toml
+++ b/src/lrs_annotation/lrs_annotation.toml
@@ -37,3 +37,4 @@ username = 'seqr'
 # Load ElasticSearch password from a secret, unless SEQR_ES_PASSWORD is set
 password_secret_id = 'seqr-es-password'
 password_project_id = 'seqr-308602'
+spot_instance = false # Don't use preemptible instances for ElasticSearch export jobs


### PR DESCRIPTION
# Purpose

  - Prevent pre-emption of the export ES index jobs, since pre-emption totally breaks the export upon VM restart
  - This change is in line with the other ES index export jobs found in cpg-flow-seqr-loader