### PR TITLE
Validate sample IDs before reheadering and optionally filter SGs on seq platform

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.17
+  VERSION: 0.2.0
   IMAGE_NAME: cpg-flow-lrs-annotation
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPG-Flow - Long Read Sequencing Annotation for seqr
 
-Version 0.1.17
+Version 0.2.0
 
 A CPG workflow for creating annotated callsets from long read data, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.1.17"
+version="0.2.0"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -117,7 +117,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/lrs_annotation/bam_to_cram_stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.17"
+current_version = "0.2.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/lrs_annotation/snps_indels_annotation.toml
+++ b/src/lrs_annotation/snps_indels_annotation.toml
@@ -3,6 +3,7 @@ name = 'snps_indels_annotation'
 
 [workflow.query_filters]
 # sequencing_types = [ 'genome', 'adaptive_sampling', ]
+# sequencing_platforms = [ 'pacbio', 'oxford-nanopore', ]
 # analysis_types = [ 'vcf', 'pacbio_vcf',]
 # variant_types = [ 'SNV', 'snp_indel', ]
 # variant_callers = [ 'deeptrio', 'deepvariant', ]

--- a/src/lrs_annotation/snps_indels_annotation_stages.py
+++ b/src/lrs_annotation/snps_indels_annotation_stages.py
@@ -57,7 +57,8 @@ class WriteLrsIdToSgIdMappingFile(stage.MultiCohortStage):
 
         lrs_mapping = query_for_lrs_mappings(
             dataset_names=get_dataset_names([d.name for d in multicohort.get_datasets()]),
-            sequencing_types=get_query_filter_from_config('sequencing_types', make_tuple=False)
+            sequencing_types=get_query_filter_from_config('sequencing_types', make_tuple=False),
+            sequencing_platforms=get_query_filter_from_config('sequencing_platforms', make_tuple=False)
         )
         lrs_sg_id_mapping = {lrs_id: mapping['sg_id'] for lrs_id, mapping in lrs_mapping.items()}
 

--- a/src/lrs_annotation/svs_annotation.toml
+++ b/src/lrs_annotation/svs_annotation.toml
@@ -7,6 +7,7 @@ gencode_gtf_file = 'gs://cpg-common-main/references/hg38/v0/gencode_47.gtf.gz'
 # Options for filtering Metamist queries for sequencing groups and their analysis
 [workflow.query_filters]
 # sequencing_types = [ 'genome', 'adaptive_sampling', ]
+# sequencing_platforms = [ 'pacbio', 'oxford-nanopore', ]
 # analysis_types = [ 'vcf', 'pacbio_vcf',]
 # variant_types = [ 'SNV', 'snp_indel', ]
 # variant_callers = [ 'deeptrio', 'deepvariant', ]

--- a/src/lrs_annotation/svs_annotation_stages.py
+++ b/src/lrs_annotation/svs_annotation_stages.py
@@ -65,6 +65,7 @@ class WriteLrsIdToSgAndSexMappingFiles(stage.MultiCohortStage):
         lrs_mapping = query_for_lrs_mappings(
             dataset_names=get_dataset_names([d.name for d in multicohort.get_datasets()]),
             sequencing_types=get_query_filter_from_config('sequencing_types', make_tuple=False),
+            sequencing_platforms=get_query_filter_from_config('sequencing_platforms', make_tuple=False)
         )
         lrs_sg_id_mapping = {lrs_id: mapping['sg_id'] for lrs_id, mapping in lrs_mapping.items()}
         lrs_sex_mapping = {lrs_id: mapping['sex'] for lrs_id, mapping in lrs_mapping.items()}


### PR DESCRIPTION
# Purpose

  - Contains changes drafted in https://github.com/populationgenomics/cpg-flow-lrs-annotation/pull/18
  - Adds a step to the VCF reformatting job - validate that the LRS IDs are actually going to be replaced by SG IDs. If the LRS ID used by the input VCF is not present in the mapping file, something is incorrect in Metamist, and the job should fail. Right now, if something is incorrect, the pipeline will succeed all the way until the Matrixtable stages, where it will break because the LRS ID was never replaced by the CPG SG ID.
