### PR TITLE
Add version back to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.134.cpg2-2
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.1.19
+ENV VERSION=0.2.0
 
 WORKDIR /cpg_flow_lrs_annotation
 


### PR DESCRIPTION
Merging #22 inadvertently undid some of #21, which added the versioning to the Dockerfile and adjusted the bumpversioning logic to target the Dockerfile. 

Because of this, the Dockerfile version change was missed when this PR merged, and so the deployed images have tags 0.1.19-x. 

This PR restores the correct version to the Dockerfile which will mean it gets built with the correct tags.
