### PR TITLE
Specify datasets for sv callsets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.134.cpg2-2
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.0
+ENV VERSION=0.2.1
 
 WORKDIR /cpg_flow_lrs_annotation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPG-Flow - Long Read Sequencing Annotation for seqr
 
-Version 0.2.0
+Version 0.2.1
 
 A CPG workflow for creating annotated callsets from long read data, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.2.0"
+version="0.2.1"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -117,7 +117,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/lrs_annotation/bam_to_cram_stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.2.0"
+current_version = "0.2.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/lrs_annotation/svs_annotation_stages.py
+++ b/src/lrs_annotation/svs_annotation_stages.py
@@ -363,6 +363,12 @@ class SubsetSVsMtToDatasetWithHail(stage.DatasetStage):
             dataset (Dataset): SGIDs specific to this dataset/project
             inputs ():
         """
+        # only create matrixtables for datasets specified in the config
+        # or, if this config option is not set, run for all datasets
+        eligible_datasets = config_retrieve(['workflow', 'write_mt_for_datasets'], default=None)
+        if eligible_datasets is not None and dataset.name not in eligible_datasets:
+            logger.info(f'Skipping MT writing for {dataset}')
+            return self.make_outputs(dataset)
         mt_path = inputs.as_path(target=get_multicohort(), stage=AnnotateCohortSVsMtFromVcfWithHail, key='mt')
         outputs = self.expected_outputs(dataset)
 
@@ -407,7 +413,12 @@ class ExportSVsMtToElasticIndex(stage.DatasetStage):
         """
         Uses the non-DataProc MT-to-ES conversion script
         """
-
+        # only create the elasticsearch index for the datasets specified in the config
+        # or, if this config option is not set, create it for all datasets
+        eligible_datasets = config_retrieve(['workflow', 'create_es_index_for_datasets'], default=None)
+        if eligible_datasets is not None and dataset.name not in eligible_datasets:
+            logger.info(f'Skipping ES index creation for {dataset}')
+            return None
         # try to generate a password here - we'll find out inside the script anyway, but
         # by that point we'd already have localised the MT, wasting time and money
         try:


### PR DESCRIPTION
# Purpose

  - Re-implementation of https://github.com/populationgenomics/cpg-flow-lrs-annotation/pull/16, but for the SV workflow
  - Will allow us to export matrixtables and es-index for specific datasets specified in the config when running the SV annotation workflow

Note - would be great if [this PR](https://github.com/populationgenomics/cpg-flow/pull/145) was merged first, so that the new image deploys with this change in the CPG-Flow install