### PR TITLE
Loguru and bugfixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.134.cpg2-2
+FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.234.cpg2-2
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.1
+ENV VERSION=0.2.2
 
 WORKDIR /cpg_flow_lrs_annotation
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.234.cpg2-2
+FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.134.cpg2-2
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV VERSION=0.2.2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPG-Flow - Long Read Sequencing Annotation for seqr
 
-Version 0.2.1
+Version 0.2.2
 
 A CPG workflow for creating annotated callsets from long read data, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.2.1"
+version="0.2.2"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -117,7 +117,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/lrs_annotation/bam_to_cram_stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.2.1"
+current_version = "0.2.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,8 +131,8 @@ replace = 'version="{new_version}"'
 
 [[tool.bumpversion.files]]
 filename = "Dockerfile"
-search = "{current_version}"
-replace = "{new_version}"
+search = "VERSION={current_version}"
+replace = "VERSION={new_version}"
 
 [[tool.bumpversion.files]]
 filename = "README.md"

--- a/src/lrs_annotation/scripts/snps_indels/vcf_to_annotate_cohort_mt.py
+++ b/src/lrs_annotation/scripts/snps_indels/vcf_to_annotate_cohort_mt.py
@@ -160,6 +160,8 @@ def annotate_cohort(
         mt = mt.annotate_globals(
             sampleType={
                 'genome': 'WGS',
+                'adaptive_sampling': 'WGS',
+                'amplicon': 'WGS',
                 'exome': 'WES',
                 'single_cell': 'RNA',
             }.get(sequencing_type, ''),

--- a/src/lrs_annotation/scripts/snps_indels/vcf_to_annotate_cohort_mt.py
+++ b/src/lrs_annotation/scripts/snps_indels/vcf_to_annotate_cohort_mt.py
@@ -2,7 +2,7 @@
 Hail Query functions for seqr loader.
 """
 from argparse import ArgumentParser
-import logging
+from loguru import logger
 
 import hail as hl
 
@@ -26,9 +26,6 @@ def annotate_cohort(
     """
     init_batch(**get_init_batch_args_for_job('annotate_cohort_snps_indels'))
 
-    # tune the logger correctly
-    logging.getLogger().setLevel(logging.INFO)
-
     # hail.zulipchat.com/#narrow/stream/223457-Hail-Batch-support/topic/permissions.20issues/near/398711114
     # don't override the block size, as it explodes the number of partitions when processing TB+ datasets
     # Each partition comes with some computational overhead, it's to be seen whether the standard block size
@@ -41,12 +38,12 @@ def annotate_cohort(
         array_elements_required=False,
     )
     mt.checkpoint(output=str(checkpoint_prefix) + 'mt-imported.mt', overwrite=True)
-    logging.info(f'Imported VCF {vcf_path} as {mt.n_partitions()} partitions')
+    logger.info(f'Imported VCF {vcf_path} as {mt.n_partitions()} partitions')
 
     # Annotate VEP. Do it before splitting multi, because we run VEP on unsplit VCF,
     # and hl.split_multi_hts can handle multiallelic VEP field.
     vep_ht = hl.read_table(vep_ht_path)
-    logging.info(
+    logger.info(
         f'Adding VEP annotations into the Matrix Table from {vep_ht_path}.'
         f'VEP loaded as {vep_ht.n_partitions()} partitions',
     )
@@ -54,7 +51,7 @@ def annotate_cohort(
 
     # Remove any contigs not in the 22 autosomes, X, Y, M
     if remove_invalid_contigs:
-        logging.info('Removing invalid contigs')
+        logger.info('Removing invalid contigs')
         # fmt: off
         chromosomes = [
             '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13',
@@ -74,13 +71,16 @@ def annotate_cohort(
     ref_ht = hl.read_table(reference_path('seqr_combined_reference_data'))
     clinvar_ht = hl.read_table(reference_path('seqr_clinvar'))
 
+    logger.info(f'Imported {reference_path("seqr_combined_reference_data")} as {ref_ht.n_partitions()} partitions')
+    logger.info(f'Imported {reference_path("seqr_clinvar")} as {clinvar_ht.n_partitions()} partitions')
+
     # If the 'AF' field is already in the entries, we should drop it
     if 'AF' in list(mt.entry):
-        logging.info('AF field already present in the entries, dropping it')
+        logger.info('AF field already present in the entries, dropping it')
         mt = mt.drop('AF')
-    logging.info('Annotating with seqr-loader fields: round 1')
+    logger.info('Annotating with seqr-loader fields: round 1')
 
-    logging.info('Annotating with clinvar and munging annotation fields')
+    logger.info('Annotating with clinvar and munging annotation fields')
     mt = mt.annotate_rows(
         # still taking just a single value here for downstream compatibility in Seqr
         AC=mt.info.AC[0],
@@ -105,7 +105,7 @@ def annotate_cohort(
     )
 
     # this was previously executed in the MtToEs job, as it wasn't possible on QoB
-    logging.info('Adding GRCh37 coords')
+    logger.info('Adding GRCh37 coords')
     liftover_path = reference_path('liftover_38_to_37')
     rg37 = hl.get_reference('GRCh37')
     rg38 = hl.get_reference('GRCh38')
@@ -116,7 +116,7 @@ def annotate_cohort(
     if 'InbreedingCoeff' in mt.info:
         mt = mt.annotate_rows(info=mt.info.drop('InbreedingCoeff'))
 
-    logging.info(
+    logger.info(
         'Annotating with seqr-loader fields: round 2 '
         '(expanding sortedTranscriptConsequences, ref_data, clinvar_data)',
     )
@@ -165,10 +165,10 @@ def annotate_cohort(
             }.get(sequencing_type, ''),
         )
 
-    logging.info('Done:')
+    logger.info('Done. Final Matrixtable structure:')
     mt.describe()
     mt.write(out_mt_path, overwrite=True)
-    logging.info(f'Written final matrix table into {out_mt_path}')
+    logger.info(f'Wrote final matrix table to {out_mt_path}')
 
 
 def cli_main():

--- a/src/lrs_annotation/scripts/svs/vcf_to_annotate_cohort_mt.py
+++ b/src/lrs_annotation/scripts/svs/vcf_to_annotate_cohort_mt.py
@@ -204,6 +204,8 @@ def annotate_cohort_sv(vcf_path: str, out_mt_path: str, gencode_gz: str, checkpo
         mt = mt.annotate_globals(
             sampleType={
                 'genome': 'WGS',
+                'adaptive_sampling': 'WGS',
+                'amplicon': 'WGS',
                 'exome': 'WES',
                 'single_cell': 'RNA',
             }.get(sequencing_type, ''),

--- a/src/lrs_annotation/scripts/svs/vcf_to_annotate_cohort_mt.py
+++ b/src/lrs_annotation/scripts/svs/vcf_to_annotate_cohort_mt.py
@@ -2,7 +2,8 @@
 Hail Query functions for seqr loader.
 """
 from argparse import ArgumentParser
-import logging
+
+from loguru import logger
 
 import hail as hl
 from itertools import chain, islice
@@ -133,7 +134,7 @@ def parse_gtf_from_local(gtf_path: str, chunk_size: int | None = None) -> hl.dic
         the gene lookup dictionary as a Hail DictExpression
     """
     gene_id_mapping = {}
-    logging.info(f'Loading {gtf_path}')
+    logger.info(f'Loading {gtf_path}')
     with gzip.open(gtf_path, 'rt') as gencode_file:
         # iterate over this file and do all the things
         for i, line in enumerate(gencode_file):
@@ -156,7 +157,7 @@ def parse_gtf_from_local(gtf_path: str, chunk_size: int | None = None) -> hl.dic
             gene_id_mapping[info_fields['gene_name']] = info_fields['gene_id'].split('.')[0]
 
     all_keys = list(gene_id_mapping.keys())
-    logging.info(f'Completed ingestion of gene-ID mapping, {len(all_keys)} entries')
+    logger.info(f'Completed ingestion of gene-ID mapping, {len(all_keys)} entries')
     if chunk_size is None:
         return [hl.literal(gene_id_mapping)]
 
@@ -180,8 +181,6 @@ def annotate_cohort_sv(vcf_path: str, out_mt_path: str, gencode_gz: str, checkpo
         checkpoint (str): CHECKPOINT!@!!
     """
     init_batch(**get_init_batch_args_for_job('annotate_cohort_sv'))
-    logger = logging.getLogger('annotate_cohort_sv')
-    logger.setLevel(logging.INFO)
 
     logger.info(f'Importing SV VCF {vcf_path}')
     mt = hl.import_vcf(

--- a/src/lrs_annotation/snps_indels_annotation_stages.py
+++ b/src/lrs_annotation/snps_indels_annotation_stages.py
@@ -351,7 +351,8 @@ class SubsetMtToDatasetWithHail(stage.DatasetStage):
 
         outputs = self.expected_outputs(dataset)
 
-        checkpoint_prefix = dataset.tmp_prefix() / 'snps_indels' / 'mt' / 'checkpoints'
+        sg_hash = workflow.get_workflow().output_version
+        checkpoint_prefix = dataset.tmp_prefix() / sg_hash / 'snps_indels' / 'mt' / 'checkpoints'
 
         jobs = annotate_dataset_jobs(
             mt_path=mt_path,

--- a/src/lrs_annotation/svs_annotation_stages.py
+++ b/src/lrs_annotation/svs_annotation_stages.py
@@ -372,7 +372,8 @@ class SubsetSVsMtToDatasetWithHail(stage.DatasetStage):
         mt_path = inputs.as_path(target=get_multicohort(), stage=AnnotateCohortSVsMtFromVcfWithHail, key='mt')
         outputs = self.expected_outputs(dataset)
 
-        checkpoint_prefix = dataset.tmp_prefix() / 'svs' / 'checkpoints'
+        sg_hash = workflow.get_workflow().output_version
+        checkpoint_prefix = dataset.tmp_prefix() / sg_hash / 'svs' / 'mt' / 'checkpoints'
 
         jobs = annotate_dataset_jobs_sv(
             mt_path=mt_path,


### PR DESCRIPTION
# Purpose

## Logging
  - Replaces instances of `logging` with `loguru.logger`, in line with best practices for CPG Flow
  - Also adds a few new logging lines to the annotate cohort job to print the number of partitions in the reference hail tables

## Bugfixes
  - Checkpoint the dataset matrixtables to a path which includes the sg hash (`workflow.output_version`) - otherwise the checkpoints conflict with each other
  - Map the cohort mt global field `sampleType` to `"WGS"` for runs where `workflow.sequencing_type == 'amplicon' OR 'adaptive_sampling'` - this will allow for setting the seq type correctly in the workflow config and not having to worry about it's impact on seqr compatibility
  - Fix to the Dockerfile version, which was trying to use australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.234, when it should use version 0.2.134.
  - Fix to the bumpversioning in pyproject.toml, who's naive string matching caused the above bullet point
  - 