### PR TITLE
Lrs sg query filters changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.137.cpg1-2
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.4
+ENV VERSION=0.2.5
 
 WORKDIR /cpg_flow_lrs_annotation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPG-Flow - Long Read Sequencing Annotation for seqr
 
-Version 0.2.4
+Version 0.2.5
 
 A CPG workflow for creating annotated callsets from long read data, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.2.4"
+version="0.2.5"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -117,7 +117,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/lrs_annotation/bam_to_cram_stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.2.4"
+current_version = "0.2.5"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/lrs_annotation/utils.py
+++ b/src/lrs_annotation/utils.py
@@ -55,7 +55,7 @@ def get_query_filter_from_config(field_name: str, make_tuple = True) -> tuple[st
     Returns tuples by default, because they are needed for use with cached functions.
     """
     if values := config_retrieve(
-        ['workflow', 'query_filter', field_name],
+        ['workflow', 'query_filters', field_name],
         default=None,
     ):
         if isinstance(values, str):


### PR DESCRIPTION
# Purpose

Adds finer granularity to the LRS ID finder for each sample that's part of the workflow, ensuring the correct LRS ID is mapped to the correct SG ID in cases where a sample has multiple long-read SGs.

## Main change

  - Add a new function `get_lrs_id_from_sample` which will try to get LRS IDs from the sample's external IDs, checking for the existence of a key like `<seq_platform>_<seq_type>_lrs_id`
    - If not available, fall back to the default external Ids key `lrs_id`, and finally the sample `meta.lrs_id`
    - This change will help distinguish the LRS IDs for samples with multiple long read sequencing groups, e.g. a lrWGS Pacbio SG, and an adaptive sampling Oxford-Nanopore SG

Most samples will only have one SG, meaning there's no need to have multiple external IDs keyed by the sequencing information. For these samples, falling back to the `externalIds.lrs_id` or `meta.lrs_id` is totally fine. However for the samples with multiple long-read SGs (only a handful at this time), this level of specificity is essential. 

## Bugfix
  - Fix a bug in fetching the `config.workflow.query_filters` where the string `query_filters` was not pluralized 