### PR TITLE
Es index analysis output fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.137.cpg1-2
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.5
+ENV VERSION=0.2.6
 
 WORKDIR /cpg_flow_lrs_annotation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPG-Flow - Long Read Sequencing Annotation for seqr
 
-Version 0.2.5
+Version 0.2.6
 
 A CPG workflow for creating annotated callsets from long read data, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.2.5"
+version="0.2.6"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -117,7 +117,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/lrs_annotation/bam_to_cram_stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.2.5"
+current_version = "0.2.6"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/lrs_annotation/snps_indels_annotation_stages.py
+++ b/src/lrs_annotation/snps_indels_annotation_stages.py
@@ -368,7 +368,7 @@ class SubsetMtToDatasetWithHail(stage.DatasetStage):
 @stage.stage(
     required_stages=[SubsetMtToDatasetWithHail],
     analysis_type='es-index',
-    analysis_keys=['index_name'],
+    analysis_keys=['done_flag'],
     update_analysis_meta=lambda x: {'seqr-dataset-type': 'SNV_INDEL'},  # noqa: ARG005
 )
 class ExportSnpsIndelsMtToESIndex(stage.DatasetStage):

--- a/src/lrs_annotation/svs_annotation_stages.py
+++ b/src/lrs_annotation/svs_annotation_stages.py
@@ -389,7 +389,7 @@ class SubsetSVsMtToDatasetWithHail(stage.DatasetStage):
 @stage.stage(
     required_stages=[SubsetSVsMtToDatasetWithHail],
     analysis_type='es-index',
-    analysis_keys=['index_name'],
+    analysis_keys=['done_flag'],
     update_analysis_meta=lambda x: {'seqr-dataset-type': 'SV'},  # noqa: ARG005
 )
 class ExportSVsMtToElasticIndex(stage.DatasetStage):


### PR DESCRIPTION
# Purpose

  - To stay compatible with Metamist 7.13.x, write the `done_flag` path to the es-index analysis record's `output`, rather than the name of the es-index, since Metamist analyses now only work with analysis outputs that have a path protocol, like `'gs://'`. 
    - Due to change: https://github.com/populationgenomics/metamist/pull/1171 

Note - seqr sync methods will need to be updated to trim the new path down to just the es-index name.