### PR TITLE
Somalier extract for long-reads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.137.cpg1-2
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.7
+ENV VERSION=0.2.8
 
 WORKDIR /cpg_flow_lrs_annotation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPG-Flow - Long Read Sequencing Annotation for seqr
 
-Version 0.2.7
+Version 0.2.8
 
 A CPG workflow for creating annotated callsets from long read data, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.2.7"
+version="0.2.8"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -111,7 +111,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/lrs_annotation/bam_to_cram_stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.2.7"
+current_version = "0.2.8"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/lrs_annotation/bam_to_cram.toml
+++ b/src/lrs_annotation/bam_to_cram.toml
@@ -11,7 +11,7 @@ analysis_type = 'cram'
 # storage_gib = 50
 
 [images]
-somalier = "australia-southeast1-docker.pkg.dev/cpg-common/images/somalier:0.2.15"
+somalier = "australia-southeast1-docker.pkg.dev/cpg-common/images/somalier:0.3.1-1"
 
 [references]
 somalier_sites = "gs://cpg-common-main/references/somalier/sites.hg38.vcf.gz"

--- a/src/lrs_annotation/bam_to_cram.toml
+++ b/src/lrs_annotation/bam_to_cram.toml
@@ -9,3 +9,9 @@ analysis_type = 'cram'
 [workflow.resource_overrides.bam_to_cram]
 # cpu_cores = 1
 # storage_gib = 50
+
+[images]
+somalier = "australia-southeast1-docker.pkg.dev/cpg-common/images/somalier:0.2.15"
+
+[references]
+somalier_sites = "gs://cpg-common-main/references/somalier/sites.hg38.vcf.gz"

--- a/src/lrs_annotation/bam_to_cram_stages.py
+++ b/src/lrs_annotation/bam_to_cram_stages.py
@@ -67,7 +67,6 @@ class CramQcSomalier(stage.SequencingGroupStage):
         cram = inputs.as_str(sequencing_group, ConvertBamToCram, 'cram')
 
         jobs = extract_somalier(
-            sg_id=sequencing_group.id,
             cram_path=cram,
             output=output,
             job_attrs=self.get_job_attrs(sequencing_group),

--- a/src/lrs_annotation/bam_to_cram_stages.py
+++ b/src/lrs_annotation/bam_to_cram_stages.py
@@ -10,6 +10,7 @@ from cpg_flow import stage, targets
 from cpg_flow.filetypes import CramPath
 
 from jobs.BamToCram import bam_to_cram
+from jobs.SomalierExtract import extract_somalier
 
 
 def make_long_read_cram_path(sg: targets.SequencingGroup) -> CramPath:
@@ -53,3 +54,24 @@ class ConvertBamToCram(stage.SequencingGroupStage):
         get_batch().write_output(job.sorted_cram, str(self.expected_outputs(sg)['cram']).removesuffix('.cram'))
 
         return self.make_outputs(sg, data=self.expected_outputs(sg), jobs=[job])
+
+
+@stage.stage(required_stages=[ConvertBamToCram])
+class CramQcSomalier(stage.SequencingGroupStage):
+    """Run somalier extract on a CRAM file."""
+
+    def expected_outputs(self, sequencing_group: targets.SequencingGroup) -> Path:
+        return make_long_read_cram_path(sequencing_group).somalier_path
+
+    def queue_jobs(self, sequencing_group: targets.SequencingGroup, inputs: stage.StageInput) -> stage.StageOutput:
+        output = self.expected_outputs(sequencing_group)
+
+        cram = inputs.as_str(sequencing_group, ConvertBamToCram, 'cram')
+
+        jobs = extract_somalier(
+            cram_path=cram,
+            output=output,
+            job_attrs=self.get_job_attrs(sequencing_group),
+        )
+
+        return self.make_outputs(sequencing_group, data=output, jobs=jobs)

--- a/src/lrs_annotation/bam_to_cram_stages.py
+++ b/src/lrs_annotation/bam_to_cram_stages.py
@@ -67,6 +67,7 @@ class CramQcSomalier(stage.SequencingGroupStage):
         cram = inputs.as_str(sequencing_group, ConvertBamToCram, 'cram')
 
         jobs = extract_somalier(
+            sg_id=sequencing_group.id,
             cram_path=cram,
             output=output,
             job_attrs=self.get_job_attrs(sequencing_group),

--- a/src/lrs_annotation/jobs/SomalierExtract.py
+++ b/src/lrs_annotation/jobs/SomalierExtract.py
@@ -7,16 +7,15 @@ from hailtop.batch.job import Job
 
 
 def extract_somalier(
-    sg_id: str,
     cram_path: str,
     output: Path,
-    job_attrs: dict,
+    job_attrs: dict[str, str],
 ) -> Job:
     """Run `somalier extract` to generate a fingerprint (i.e. a `*.somalier` file)."""
 
     batch_instance = hail_batch.get_batch()
 
-    job = batch_instance.new_job('Somalier extract', attributes=job_attrs | {'tool': 'somalier'})
+    job = batch_instance.new_job('Somalier extract', job_attrs | {'tool': 'somalier'})
 
     job.image(config.config_retrieve(['images', 'somalier']))
     storage_gb = config.config_retrieve(['workflow', 'resource_overrides', 'bam_to_cram', 'storage_gib'], 50)
@@ -33,9 +32,8 @@ def extract_somalier(
         crai=f'{cram_path}.crai',
     ).cram
 
-    sg_id_prefix = sg_id + '_'
     job.command(f"""
-    somalier extract -d extracted/ --sites {sites} -f {ref.base} --sample-prefix {sg_id_prefix} {cram_localised}
+    somalier extract -d extracted/ --sites {sites} -f {ref.base} {cram_localised}
     mv extracted/*.somalier {job.output_file}
     """)
     batch_instance.write_output(job.output_file, output)

--- a/src/lrs_annotation/jobs/SomalierExtract.py
+++ b/src/lrs_annotation/jobs/SomalierExtract.py
@@ -1,0 +1,40 @@
+"""
+Job for CRAM fingerprinting using Somalier.
+"""
+
+from cpg_utils import Path, config, hail_batch
+from hailtop.batch.job import Job
+
+
+def extract_somalier(
+    cram_path: str,
+    output: Path,
+    job_attrs: dict,
+) -> Job:
+    """Run `somalier extract` to generate a fingerprint (i.e. a `*.somalier` file)."""
+
+    batch_instance = hail_batch.get_batch()
+
+    job = batch_instance.new_job('Somalier extract', attributes=job_attrs | {'tool': 'somalier'})
+
+    job.image(config.config_retrieve(['images', 'somalier']))
+    storage_gb = config.config_retrieve(['workflow', 'resource_overrides', 'bam_to_cram', 'storage_gib'], 50)
+    job.storage(f'{storage_gb}GB')
+
+    ref = hail_batch.fasta_res_group(batch_instance)
+
+    # read in the somalier sites VCF
+    sites = batch_instance.read_input(config.config_retrieve(['references', 'somalier_sites']))
+
+    # read in the CRAM and index
+    cram_localised = batch_instance.read_input_group(
+        cram=cram_path,
+        crai=f'{cram_path}.crai',
+    ).cram
+
+    job.command(f"""
+    somalier extract -d extracted/ --sites {sites} -f {ref.base} {cram_localised}
+    mv extracted/*.somalier {job.output_file}
+    """)
+    batch_instance.write_output(job.output_file, output)
+    return job

--- a/src/lrs_annotation/jobs/SomalierExtract.py
+++ b/src/lrs_annotation/jobs/SomalierExtract.py
@@ -7,6 +7,7 @@ from hailtop.batch.job import Job
 
 
 def extract_somalier(
+    sg_id: str,
     cram_path: str,
     output: Path,
     job_attrs: dict,
@@ -33,7 +34,7 @@ def extract_somalier(
     ).cram
 
     job.command(f"""
-    somalier extract -d extracted/ --sites {sites} -f {ref.base} {cram_localised}
+    somalier extract -d extracted/ --sites {sites} -f {ref.base} --sample-prefix {sg_id} {cram_localised}
     mv extracted/*.somalier {job.output_file}
     """)
     batch_instance.write_output(job.output_file, output)

--- a/src/lrs_annotation/jobs/SomalierExtract.py
+++ b/src/lrs_annotation/jobs/SomalierExtract.py
@@ -33,8 +33,9 @@ def extract_somalier(
         crai=f'{cram_path}.crai',
     ).cram
 
+    sg_id_prefix = sg_id + '_'
     job.command(f"""
-    somalier extract -d extracted/ --sites {sites} -f {ref.base} --sample-prefix {sg_id} {cram_localised}
+    somalier extract -d extracted/ --sites {sites} -f {ref.base} --sample-prefix {sg_id_prefix} {cram_localised}
     mv extracted/*.somalier {job.output_file}
     """)
     batch_instance.write_output(job.output_file, output)

--- a/src/lrs_annotation/run_workflow.py
+++ b/src/lrs_annotation/run_workflow.py
@@ -8,7 +8,7 @@ from argparse import ArgumentParser
 
 from cpg_flow.workflow import run_workflow
 
-from lrs_annotation.bam_to_cram_stages import ConvertBamToCram
+from lrs_annotation.bam_to_cram_stages import ConvertBamToCram, CramQcSomalier
 from lrs_annotation.snps_indels_annotation_stages import ExportSnpsIndelsMtToESIndex
 from lrs_annotation.svs_annotation_stages import ExportSVsMtToElasticIndex
 
@@ -23,7 +23,7 @@ def cli_main():
     args = parser.parse_args()
 
     if args.workflow == 'bam_to_cram':
-        stages = [ConvertBamToCram]
+        stages = [ConvertBamToCram, CramQcSomalier]
     elif args.workflow == 'snps_indels':
         stages = [ExportSnpsIndelsMtToESIndex]
     elif args.workflow == 'svs':


### PR DESCRIPTION
# Purpose

  - Adds a stage to generate `.somalier` fingerprint files for the long-read crams using `somalier extract`

## Proposed Changes

  - Re-implement the Somalier stage and job from cpg-flow-align-genotype's [CramQcSomalier](https://github.com/populationgenomics/cpg-flow-align-genotype/blob/f9a0df2d7c38a09fc754f212a0559b8d36e5b0e4/src/align_genotype/stages.py#L118) stage

## Future Scope (beyond this PR)

- [ ] Add reheadering to `BamToCram` stage, to ensure the SG IDs are ending up in the cram headers (important for Somalier)
- [ ] Rename the workflow from `"bam_to_cram"` to something different like `"read_file_processing"`, as this workflow has now been expanded to cover more than just converting bams to crams, and will likely be expanded with other read file processing and QC stages in future
- [ ] Add a somalier relate stage & checks, a la cpg-flow-align-genotype's [SomalierPedigree](https://github.com/populationgenomics/cpg-flow-align-genotype/blob/f9a0df2d7c38a09fc754f212a0559b8d36e5b0e4/src/align_genotype/dataset_stages.py#L24) stage
