### PR TITLE
Vcf to mt stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.137.cpg1-2
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.8
+ENV VERSION=0.2.9
 
 WORKDIR /cpg_flow_lrs_annotation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPG-Flow - Long Read Sequencing Annotation for seqr
 
-Version 0.2.8
+Version 0.2.9
 
 A CPG workflow for creating annotated callsets from long read data, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.2.8"
+version="0.2.9"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -111,7 +111,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/lrs_annotation/bam_to_cram_stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.2.8"
+current_version = "0.2.9"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/lrs_annotation/jobs/snps_indels/MergeVcfs.py
+++ b/src/lrs_annotation/jobs/snps_indels/MergeVcfs.py
@@ -1,17 +1,18 @@
+from cpg_utils import hail_batch
 from cpg_utils.config import config_retrieve
-from cpg_utils.hail_batch import Batch
 
 from lrs_annotation.utils import get_resource_overrides_for_job
 
 
 def merge_snps_indels_vcf_with_bcftools(
-    batch: Batch,
-    vcf_paths: str,
+    vcf_paths: list[str],
     job_attrs: dict | None = None,
 ):
     """
     Naively merge SNPs and Indels VCFs using bcftools.
     """
+    batch = hail_batch.get_batch()
+
     # Input files
     batch_vcfs = [
         batch.read_input_group(**{'vcf.gz': each_vcf, 'vcf.gz.tbi': f'{each_vcf}.tbi'})['vcf.gz']

--- a/src/lrs_annotation/jobs/snps_indels/ModifyVcf.py
+++ b/src/lrs_annotation/jobs/snps_indels/ModifyVcf.py
@@ -1,5 +1,5 @@
+from cpg_utils import Path, hail_batch
 from cpg_utils.config import config_retrieve
-from cpg_utils.hail_batch import get_batch
 from hailtop.batch.job import Job
 
 from lrs_annotation.utils import get_resource_overrides_for_job
@@ -9,7 +9,7 @@ def bcftools_reformat(
     vcf_path: str,
     job_name: str,
     job_attrs: dict,
-    lrs_sg_id_mapping_path: str,
+    lrs_sg_id_mapping_path: Path,
 ) -> Job:
     """
     Reformat SNPs and Indels VCFs using bcftools.
@@ -20,17 +20,19 @@ def bcftools_reformat(
     Uppercases the allele strings with awk.
     Finally, sort and index the VCF with bcftools sort.
     """
+    batch_instance = hail_batch.get_batch()
+
     # Input files
-    local_vcf = get_batch().read_input(vcf_path)
-    local_id_mapping = get_batch().read_input(lrs_sg_id_mapping_path)
+    local_vcf = batch_instance.read_input(vcf_path)
+    local_id_mapping = batch_instance.read_input(lrs_sg_id_mapping_path)
 
     # Required file for normalisation
     ref_fasta = config_retrieve(['workflow', 'ref_fasta'])
-    fasta = get_batch().read_input_group(**{'fa': ref_fasta, 'fa.fai': f'{ref_fasta}.fai'})['fa']
+    fasta = batch_instance.read_input_group(**{'fa': ref_fasta, 'fa.fai': f'{ref_fasta}.fai'})['fa']
 
     # Use BCFtools to reheader the VCF, replacing the LRS IDs with the SG IDs
-    job = get_batch().new_job(job_name, job_attrs)
-    job.image(image=config_retrieve(['images', 'bcftools']))
+    job = batch_instance.new_job(job_name, job_attrs)
+    job.image(config_retrieve(['images', 'bcftools']))
     job.declare_resource_group(vcf_out={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'})
     job = get_resource_overrides_for_job(job, 'reformat_snps_indels_vcf')
 

--- a/src/lrs_annotation/jobs/snps_indels/VcfToUnannotatedMt.py
+++ b/src/lrs_annotation/jobs/snps_indels/VcfToUnannotatedMt.py
@@ -1,0 +1,26 @@
+from cpg_utils import Path
+from cpg_utils.config import config_retrieve
+from cpg_utils.hail_batch import get_batch
+from hailtop.batch.job import Job
+
+from lrs_annotation.scripts.snps_indels import vcf_to_unannotated_mt
+
+
+def vcf_to_unannotated_mt_job(
+    vcf_path: Path,
+    out_mt_path: Path,
+    job_attrs: dict | None = None,
+) -> Job:
+    """
+    Convert VCF to unannotated matrix table for Talos.
+    """
+    j = get_batch().new_job('Convert VCF to unannotated MT', job_attrs)
+    j.image(config_retrieve(['workflow', 'driver_image']))
+    j.command(
+        f"""
+        python3 {vcf_to_unannotated_mt.__file__} \\
+            --vcf_path {vcf_path} \\
+            --out_mt_path {out_mt_path}
+        """
+    )
+    return j

--- a/src/lrs_annotation/lrs_annotation.toml
+++ b/src/lrs_annotation/lrs_annotation.toml
@@ -16,6 +16,7 @@ sequencing_type = 'genome'
 ref_fasta = 'gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
 
 # uncomment these and add dataset names to run these stages only for specific datasets
+# write_unannotated_mt_for_datasets = []
 # write_mt_for_datasets = []
 # create_es_index_for_datasets = []
 

--- a/src/lrs_annotation/run_workflow.py
+++ b/src/lrs_annotation/run_workflow.py
@@ -9,7 +9,7 @@ from argparse import ArgumentParser
 from cpg_flow.workflow import run_workflow
 
 from lrs_annotation.bam_to_cram_stages import ConvertBamToCram, CramQcSomalier
-from lrs_annotation.snps_indels_annotation_stages import ExportSnpsIndelsMtToESIndex
+from lrs_annotation.snps_indels_annotation_stages import ExportSnpsIndelsMtToESIndex, ExportSnpsIndelsVcfToMt
 from lrs_annotation.svs_annotation_stages import ExportSVsMtToElasticIndex
 
 
@@ -25,7 +25,7 @@ def cli_main():
     if args.workflow == 'bam_to_cram':
         stages = [ConvertBamToCram, CramQcSomalier]
     elif args.workflow == 'snps_indels':
-        stages = [ExportSnpsIndelsMtToESIndex]
+        stages = [ExportSnpsIndelsMtToESIndex, ExportSnpsIndelsVcfToMt]
     elif args.workflow == 'svs':
         stages = [ExportSVsMtToElasticIndex]
     else:

--- a/src/lrs_annotation/scripts/snps_indels/vcf_to_unannotated_mt.py
+++ b/src/lrs_annotation/scripts/snps_indels/vcf_to_unannotated_mt.py
@@ -1,0 +1,48 @@
+from argparse import ArgumentParser
+
+import hail as hl
+from cpg_utils.hail_batch import genome_build, init_batch
+from loguru import logger
+
+from lrs_annotation.utils import get_init_batch_args_for_job
+
+
+def vcf_to_unannotated_mt(
+    vcf_path: str,
+    out_mt_path: str,
+):
+    """
+    Convert VCF to matrix table, unannotated for Talos.
+    """
+    init_batch(**get_init_batch_args_for_job('vcf_to_unannotated_mt'))
+
+    mt = hl.import_vcf(
+        vcf_path,
+        reference_genome=genome_build(),
+        skip_invalid_loci=True,
+        force_bgz=True,
+        array_elements_required=False,
+    )
+    logger.info(f'Imported VCF {vcf_path} as {mt.n_partitions()} partitions')
+    mt.describe()
+    mt.write(out_mt_path, overwrite=True)
+    logger.info(f'Wrote final matrix table to {out_mt_path}')
+
+
+def cli_main():
+    """
+    command line entrypoint
+    """
+    parser = ArgumentParser()
+    parser.add_argument('--vcf_path', type=str, required=True, help='Path to the input VCF file')
+    parser.add_argument('--out_mt_path', type=str, required=True, help='Path to the output Matrix Table file')
+    args = parser.parse_args()
+
+    vcf_to_unannotated_mt(
+        vcf_path=args.vcf_path,
+        out_mt_path=args.out_mt_path,
+    )
+
+
+if __name__ == '__main__':
+    cli_main()

--- a/src/lrs_annotation/snps_indels_annotation_stages.py
+++ b/src/lrs_annotation/snps_indels_annotation_stages.py
@@ -17,6 +17,7 @@ from jobs.snps_indels.AnnotateWithVep import add_vep_jobs
 from jobs.snps_indels.MergeVcfs import merge_snps_indels_vcf_with_bcftools
 from jobs.snps_indels.ModifyVcf import bcftools_reformat
 from jobs.snps_indels.SplitMergedVcfAndGetSitesOnlyForVep import split_merged_vcf_and_get_sitesonly_vcfs_for_vep
+from jobs.snps_indels.VcfToUnannotatedMt import vcf_to_unannotated_mt_job
 from loguru import logger
 from utils import (
     es_password,
@@ -154,6 +155,48 @@ class MergeVcfsWithBcftools(stage.MultiCohortStage):
         get_batch().write_output(merge_job.output, str(outputs['vcf']).removesuffix('.vcf.gz'))
 
         return self.make_outputs(multicohort, data=outputs, jobs=merge_job)
+
+
+@stage.stage(required_stages=[ModifyVcf, MergeVcfsWithBcftools])
+class ExportSnpsIndelsVcfToMt(stage.DatasetStage):
+    """
+    Writes the merged VCF to a matrix table at the dataset level, without any annotation.
+
+    This optional step is for exporting the merged VCFs to dataset level matrixtables
+    to be used as inputs to the Talos workflow, which handles annotation separately.
+    """
+
+    def expected_outputs(self, dataset: targets.Dataset) -> dict[str, Path]:
+        """
+        Expected to write a matrix table.
+        """
+        sg_hash = workflow.get_workflow().output_version
+        mt_name = f'LongReadSNPsIndels-{sg_hash}-{dataset.name}'
+        return {'mt': dataset.prefix() / 'unannotated' / 'snps_indels' / f'{mt_name}.mt'}
+
+    def queue_jobs(self, dataset: targets.Dataset, inputs: stage.StageInput) -> stage.StageOutput:
+        """
+        Queue job(s) to convert the merged VCF to a matrixtable without annotation
+        """
+        assert len(get_multicohort().get_datasets()) == 1, 'Expected only one dataset in the multicohort for this stage'
+
+        # only create matrixtables for datasets specified in the config
+        # or, if this config option is not set, run for all datasets
+        eligible_datasets = config_retrieve(['workflow', 'write_unannotated_mt_for_datasets'], default=None)
+        if eligible_datasets is not None and dataset.name not in eligible_datasets:
+            logger.info(f'Skipping unannotated MT writing for {dataset}')
+            return self.make_outputs(dataset)
+
+        vcf_path = inputs.as_path(target=get_multicohort(), stage=AnnotateCohortMtFromVcfWithHail, key='mt')
+        outputs = self.expected_outputs(dataset)
+
+        job = vcf_to_unannotated_mt_job(
+            vcf_path=vcf_path,
+            out_mt_path=outputs['mt'],
+            job_attrs=self.get_job_attrs(dataset),
+        )
+
+        return self.make_outputs(dataset, data=outputs, jobs=job)
 
 
 @stage.stage(required_stages=[ModifyVcf, MergeVcfsWithBcftools])

--- a/src/lrs_annotation/snps_indels_annotation_stages.py
+++ b/src/lrs_annotation/snps_indels_annotation_stages.py
@@ -125,7 +125,7 @@ class MergeVcfsWithBcftools(stage.MultiCohortStage):
             'index': self.tmp_prefix / 'snps_indels' / 'merged_reformatted.vcf.gz.tbi',
         }
 
-    def queue_jobs(self, multicohort: targets.MultiCohort, inputs: stage.StageInput) -> stage.StageOutput:
+    def queue_jobs(self, multicohort: targets.MultiCohort, inputs: stage.StageInput) -> stage.StageOutput | None:
         """
         Use bcftools to merge all the VCFs, and then fill in the tags (requires bcftools 1.18+)
         """
@@ -146,7 +146,6 @@ class MergeVcfsWithBcftools(stage.MultiCohortStage):
         ]
 
         merge_job = merge_snps_indels_vcf_with_bcftools(
-            batch=get_batch(),
             vcf_paths=vcf_paths,
             job_attrs={'tool': 'bcftools'},
         )
@@ -178,7 +177,10 @@ class ExportSnpsIndelsVcfToMt(stage.DatasetStage):
         """
         Queue job(s) to convert the merged VCF to a matrixtable without annotation
         """
-        assert len(get_multicohort().get_datasets()) == 1, 'Expected only one dataset in the multicohort for this stage'
+        mc = get_multicohort()
+
+        # current VCF merging implementation is multicohort, so multiple datasets would require subsettting
+        assert len(mc.get_datasets()) == 1, 'Expected only one dataset in the multicohort for this stage'
 
         # only create matrixtables for datasets specified in the config
         # or, if this config option is not set, run for all datasets
@@ -187,7 +189,12 @@ class ExportSnpsIndelsVcfToMt(stage.DatasetStage):
             logger.info(f'Skipping unannotated MT writing for {dataset}')
             return self.make_outputs(dataset)
 
-        vcf_path = inputs.as_path(target=get_multicohort(), stage=AnnotateCohortMtFromVcfWithHail, key='mt')
+        if len(inputs.as_dict_by_target(ModifyVcf)) == 1:
+            sg = mc.get_sequencing_groups()[0]
+            vcf_path = inputs.as_path(sg, ModifyVcf, 'vcf')
+        else:
+            vcf_path = inputs.as_path(mc, MergeVcfsWithBcftools, 'vcf')
+
         outputs = self.expected_outputs(dataset)
 
         job = vcf_to_unannotated_mt_job(


### PR DESCRIPTION
# Purpose

  - Add an optional terminating stage to export dataset level matrixtables for input to Talos


## Proposed Changes

  - Assume all cohorts in `workflow.input_cohorts` contains only a single dataset, as the earlier stage that creates the VCF is a multicohort stage. This can only work to create simple dataset-level Talos inputs if the input "multicohort" consists of only one dataset.
  - Run the pipeline with `workflow.last_stages = ["ExportSnpsIndelsVcfToMt"]` and `workflow.write_unannotated_mt_for_datasets = ["my-dataset"]`