### PR TITLE
Allow reusing subset mt intermediates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.137.cpg1-2
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.10
+ENV VERSION=0.2.11
 
 WORKDIR /cpg_flow_lrs_annotation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPG-Flow - Long Read Sequencing Annotation for seqr
 
-Version 0.2.10
+Version 0.2.11
 
 A CPG workflow for creating annotated callsets from long read data, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.2.10"
+version="0.2.11"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -98,7 +98,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/lrs_annotation/bam_to_cram_stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.2.10"
+current_version = "0.2.11"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/lrs_annotation/jobs/snps_indels/AnnotateDatasetMatrixtable.py
+++ b/src/lrs_annotation/jobs/snps_indels/AnnotateDatasetMatrixtable.py
@@ -1,7 +1,9 @@
+from cpg_flow.utils import can_reuse
 from cpg_utils import Path
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import get_batch
 from hailtop.batch.job import Job
+from loguru import logger
 
 from lrs_annotation.scripts import subset_mt_to_sgs
 from lrs_annotation.scripts.snps_indels import annotate_dataset_mt
@@ -47,6 +49,12 @@ def annotate_dataset_jobs(
             --out_mt_path {out_mt_path}
         """
     )
+
+    if can_reuse(subset_mt_path / '_SUCCESS'):
+        logger.info(f'Skipping subset job since {subset_mt_path / "_SUCCESS"} exists and can be reused')
+        logger.info('To disable this, set workflow.check_intermediates to False in the config')
+        return [annotate_j]
+
     annotate_j.depends_on(subset_j)
 
     return [subset_j, annotate_j]


### PR DESCRIPTION
# Purpose

  - The subset mt job can run successfully, but if the annotation job that follows fails, then the subset needs to run again even if it exists
  - This change allows re-use of existing subset results via the `cpg_flow.utils.can_reuse` function, which checks the workflow config for `workflow.check_intermediates = True`

## Proposed Changes

  - In some cases, the subset job succeeds, but the annotation job fails
  - Because these outputs are from the same stage, and the expected outputs are from the annotation job, if the annotation fails then the subset job will re-run
  - e.g
    - Subset job succeeds [here](https://batch.hail.populationgenomics.org.au/batches/1127340), but annotation fails
    - Resubmission causes subset job to re-run unnecessarily [here](https://batch.hail.populationgenomics.org.au/batches/1127368)
 - To reuse this subset mt, check for existence of the subsetted mt's `_SUCCESS` file and the config bool flag `workflow.check_intermediates`, and then only submit the annotate mt job if these conditions for reuse are met.
