### PR TITLE
Joint called sv vcfs missing2ref

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.12
+ENV VERSION=0.2.13
 
 WORKDIR /cpg_flow_lrs_annotation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPG-Flow - Long Read Sequencing Annotation for seqr
 
-Version 0.2.12
+Version 0.2.13
 
 A CPG workflow for creating annotated callsets from long read data, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.2.12"
+version="0.2.13"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -98,7 +98,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/lrs_annotation/bam_to_cram_stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.2.12"
+current_version = "0.2.13"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/lrs_annotation/jobs/svs/MergeVcfs.py
+++ b/src/lrs_annotation/jobs/svs/MergeVcfs.py
@@ -25,7 +25,7 @@ def merge_svs_vcf_with_bcftools(
     # BCFtools options breakdown:
     #   --threads: number of threads to use
     #   -m: merge strategy (none means multiple records for multiallelic sites)
-    #   -0: assume genotypes at missing sites are 0/0
+    #   -0: assume genotypes at missing sites are 0/0 (note - does not convert existing missing genotypes to 0/0)
     #   -Oz: bgzip output (compressed VCF)
     #   -o: output file name
     #   --write-index: write index file (only for bcftools 1.18+. Occasionally bugged for < 1.21)

--- a/src/lrs_annotation/jobs/svs/MergeVcfs.py
+++ b/src/lrs_annotation/jobs/svs/MergeVcfs.py
@@ -29,9 +29,11 @@ def merge_svs_vcf_with_bcftools(
     #   -Oz: bgzip output (compressed VCF)
     #   -o: output file name
     #   --write-index: write index file (only for bcftools 1.18+. Occasionally bugged for < 1.21)
+    #   +missing2ref: plugin to convert missing genotypes to homozygous reference (0/0)
     #   +fill-tags: plugin to compute and fill in the INFO tags (AF, AN, AC)
     merge_job.command(
         f'bcftools merge {" ".join(batch_vcfs)} --threads 4 -m none -0 -Ou | '
+        f'bcftools +missing2ref -Ou | '
         f'bcftools +fill-tags -Oz -o {merge_job.output["vcf.gz"]} --write-index=tbi -- -t AF,AN,AC'
     )
 


### PR DESCRIPTION
# Purpose

 - Resolve issue with "NO CALL" genotypes appearing in seqr for parental samples with missing genotype data, instead fill these with REF 

## Proposed Changes

  - In trio merged SV VCFs, sometimes the parents genotype is `./.` - i.e. missing
  - During the `bcftools merge` step of the pipeline, we use the `-0` flag, which converts missing genotypes in the input VCFs to REF. 
    - HOWEVER - this does NOT apply to missing genotypes for samples in multisample VCFs. So when we merge a trio VCF, the missing genotypes in the parental samples will still be missing in the merged VCF. We don't want this. So use the bcftools plugin `missing2ref` to make sure all missing genotypes get converted.

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
