### PR TITLE
SNPs Indels pipeline - missing2ref and Skip SGs without VCFs 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.13
+ENV VERSION=0.2.14
 
 WORKDIR /cpg_flow_lrs_annotation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPG-Flow - Long Read Sequencing Annotation for seqr
 
-Version 0.2.13
+Version 0.2.14
 
 A CPG workflow for creating annotated callsets from long read data, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.2.13"
+version="0.2.14"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -98,7 +98,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/lrs_annotation/bam_to_cram_stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.2.13"
+current_version = "0.2.14"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/lrs_annotation/jobs/snps_indels/MergeVcfs.py
+++ b/src/lrs_annotation/jobs/snps_indels/MergeVcfs.py
@@ -31,8 +31,10 @@ def merge_snps_indels_vcf_with_bcftools(
     #   -o: output file name
     #   -W: write index file (only for bcftools 1.18+. Occasionally bugged for < 1.21)
     #   +fill-tags: plugin to compute and fill in the INFO tags (AF, AN, AC)
+    #   +missing2ref: plugin to convert missing genotypes to homozygous reference (0/0)
     merge_job.command(
         f'bcftools merge {" ".join(batch_vcfs)} --threads 4 -m none -0 -Ou | '
+        f'bcftools +missing2ref -Ou | '
         f'bcftools +fill-tags -Oz -o {merge_job.output["vcf.gz"]} -W=tbi -- -t AF,AN,AC'
     )
 

--- a/src/lrs_annotation/snps_indels_annotation_stages.py
+++ b/src/lrs_annotation/snps_indels_annotation_stages.py
@@ -97,6 +97,9 @@ class ModifyVcf(stage.SequencingGroupStage):
             ' Adjust the query filter or the input cohorts'
         )
 
+        if sg.id not in sg_vcfs:
+            return None
+
         joint_called = sg_vcfs[sg.id]['meta'].get('joint_called', False)
 
         # Input VCF and reheadering file


### PR DESCRIPTION
# Purpose

  - Fill missing variants with ref, just like #41 
  - Skip the VCF parsing for SGs that don't have a VCF - these will be the parents of trio called VCFs

## Proposed Changes

  - Handle the skipping the same as the SV pipeline does: https://github.com/populationgenomics/cpg-flow-lrs-annotation/blob/main/src/lrs_annotation/svs_annotation_stages.py#L129

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
