### PR TITLE
Quick registration of MT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.15
+ENV VERSION=0.2.16
 
 WORKDIR /cpg_flow_lrs_annotation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPG-Flow - Long Read Sequencing Annotation for seqr
 
-Version 0.2.15
+Version 0.2.16
 
 A CPG workflow for creating annotated callsets from long read data, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.2.15"
+version="0.2.16"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -98,7 +98,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/lrs_annotation/bam_to_cram_stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.2.15"
+current_version = "0.2.16"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/lrs_annotation/snps_indels_annotation_stages.py
+++ b/src/lrs_annotation/snps_indels_annotation_stages.py
@@ -119,7 +119,7 @@ class ModifyVcf(stage.SequencingGroupStage):
         return self.make_outputs(target=sg, jobs=[reformatting_job], data=outputs)
 
 
-@stage.stage(required_stages=ModifyVcf, analysis_type='joint-calling', analysis_keys=['vcf'])
+@stage.stage(required_stages=ModifyVcf)
 class MergeVcfsWithBcftools(stage.MultiCohortStage):
     """
     Merge the reformatted SNPs Indels VCFs together with bcftools

--- a/src/lrs_annotation/snps_indels_annotation_stages.py
+++ b/src/lrs_annotation/snps_indels_annotation_stages.py
@@ -119,7 +119,7 @@ class ModifyVcf(stage.SequencingGroupStage):
         return self.make_outputs(target=sg, jobs=[reformatting_job], data=outputs)
 
 
-@stage.stage(required_stages=ModifyVcf)
+@stage.stage(required_stages=ModifyVcf, analysis_type='joint-calling', analysis_keys=['vcf'])
 class MergeVcfsWithBcftools(stage.MultiCohortStage):
     """
     Merge the reformatted SNPs Indels VCFs together with bcftools
@@ -162,7 +162,7 @@ class MergeVcfsWithBcftools(stage.MultiCohortStage):
         return self.make_outputs(multicohort, data=outputs, jobs=merge_job)
 
 
-@stage.stage(required_stages=[ModifyVcf, MergeVcfsWithBcftools])
+@stage.stage(required_stages=[ModifyVcf, MergeVcfsWithBcftools], analysis_keys=['mt'], analysis_type='matrixtable')
 class ExportSnpsIndelsVcfToMt(stage.DatasetStage):
     """
     Writes the merged VCF to a matrix table at the dataset level, without any annotation.


### PR DESCRIPTION
# Purpose

  - LRS MatrixTables aren't being registered in Metamist

## Proposed Changes

  - Registers the intended-for-talos MT as a `matrixtable` analysis
  - This registration will also include the SGs, which can be used downstream to ensure an appropriate MT is being selected for the analysis Cohort

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
