### PR TITLE
Resolve fatal import error, and pleasing the linter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.16
+ENV VERSION=0.2.17
 
 WORKDIR /cpg_flow_lrs_annotation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPG-Flow - Long Read Sequencing Annotation for seqr
 
-Version 0.2.16
+Version 0.2.17
 
 A CPG workflow for creating annotated callsets from long read data, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers=[
 
 dependencies=[
     'cpg-flow~=1.3',
+    'cpg-utils>=5.7.1',
     'elasticsearch==8.*',
     'pyfaidx>=0.8.1.1',
 ]
@@ -88,7 +89,11 @@ ignore = [
 ]
 
 [tool.ruff.lint.isort]
-section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
+section-order = ["future", "standard-library", "third-party", "hail", "cpg", "first-party", "local-folder"]
+
+[tool.ruff.lint.isort.sections]
+cpg = ["metamist", "cpg_flow", "cpg_utils"]
+hail = ["hail", "hailtop"]
 
 [tool.ruff.lint.per-file-ignores]
 # suppress the ARG002 "Unused method argument" warning in the stages.py file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.2.16"
+version="0.2.17"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -103,7 +103,7 @@ hail = ["hail", "hailtop"]
 "src/lrs_annotation/bam_to_cram_stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.2.16"
+current_version = "0.2.17"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/lrs_annotation/inputs.py
+++ b/src/lrs_annotation/inputs.py
@@ -4,10 +4,10 @@ Methods for querying Metamist for long-read sequencing VCFs and related metadata
 
 from functools import cache
 
-from cpg_utils.config import config_retrieve
 from loguru import logger
+
+from cpg_utils.config import config_retrieve, dataset_for_access_level
 from metamist.graphql import gql, query
-from utils import get_dataset_name
 
 VCF_QUERY = gql(
     """
@@ -94,7 +94,7 @@ def find_sgs_to_skip(sg_vcf_dict: dict[str, dict]) -> set[str]:
 
 
 @cache
-def query_for_lrs_vcfs(dataset_name: str) -> dict[str, dict | list[str]]:
+def query_for_lrs_vcfs(dataset_name: str) -> tuple[list[str], dict[str, dict]]:
     """
     Query metamist for the long-read sequencing VCFs. The VCFs are filtered by the values specified in
     the workflow.query_filters config dictionary, using the analysis.meta field.
@@ -175,10 +175,7 @@ def query_for_lrs_vcfs(dataset_name: str) -> dict[str, dict | list[str]]:
         )
     if not query_filters.get('prefer_joint_called', False):
         # If we are not preferring joint-called VCFs, just return the single-sample VCFs
-        return {
-            'sg_ids': list(single_sample_vcfs.keys()),
-            'vcfs': single_sample_vcfs,
-        }
+        return list(single_sample_vcfs.keys()), single_sample_vcfs
 
     # If joint_called is True, we need to query for the joint-called trio VCFs
     # and prefer them over the single-sample VCFs of parents in joint-called trios
@@ -228,13 +225,10 @@ def query_for_lrs_vcfs(dataset_name: str) -> dict[str, dict | list[str]]:
             continue
         vcfs_for_sgs[sg_id] = vcf_analysis
 
-    return {
-        # SG IDs include the skipped parental ones, so that we can still
-        # reference them in the workflow, but the vcfs dict only contains
-        # the VCFs that are not skipped.
-        'sg_ids': list(vcfs_for_sgs.keys()) + list(sgs_to_skip),
-        'vcfs': vcfs_for_sgs,
-    }
+    # SG IDs include the skipped parental ones, so that we can still
+    # reference them in the workflow, but the vcfs dict only contains
+    # the VCFs that are not skipped.
+    return list(vcfs_for_sgs.keys()) + list(sgs_to_skip), vcfs_for_sgs
 
 
 def query_for_lrs_mappings(
@@ -292,7 +286,7 @@ def get_lrs_id_from_sample(
     return sample['meta'].get('lrs_id', None)
 
 
-def get_sgs_from_datasets(multicohort_datasets: list[str]) -> dict[str, list[str] | dict]:
+def get_sgs_from_datasets(multicohort_datasets: list[str]) -> tuple[list[str], dict]:
     """
     Returns the sequencing group IDs from multicohort datasets, filtered to the
     sequencing groups that are actually present in the workflow run.
@@ -300,6 +294,7 @@ def get_sgs_from_datasets(multicohort_datasets: list[str]) -> dict[str, list[str
     sg_ids: list[str] = []
     vcfs: dict[str, dict] = {}
     for dataset in multicohort_datasets:
-        sg_ids.extend(query_for_lrs_vcfs(get_dataset_name(dataset))['sg_ids'])
-        vcfs.update(query_for_lrs_vcfs(get_dataset_name(dataset))['vcfs'])  # type: ignore[arg-type]
-    return {'sg_ids': sg_ids, 'vcfs': vcfs}
+        query_sgs, query_vcfs = query_for_lrs_vcfs(dataset_for_access_level(dataset))
+        sg_ids.extend(query_sgs)
+        vcfs.update(query_vcfs)  # type: ignore[arg-type]
+    return sg_ids, vcfs

--- a/src/lrs_annotation/jobs/BamToCram.py
+++ b/src/lrs_annotation/jobs/BamToCram.py
@@ -2,12 +2,13 @@
 Convert BAM to CRAM.
 """
 
+from hailtop.batch import ResourceGroup
+from hailtop.batch.job import Job
+
 from cpg_flow.resources import STANDARD
 from cpg_utils import to_path
 from cpg_utils.config import config_retrieve, image_path, reference_path
 from cpg_utils.hail_batch import Batch, command
-from hailtop.batch import ResourceGroup
-from hailtop.batch.job import Job
 
 
 def bam_to_cram(

--- a/src/lrs_annotation/jobs/SomalierExtract.py
+++ b/src/lrs_annotation/jobs/SomalierExtract.py
@@ -2,8 +2,9 @@
 Job for CRAM fingerprinting using Somalier.
 """
 
-from cpg_utils import Path, config, hail_batch
 from hailtop.batch.job import Job
+
+from cpg_utils import Path, config, hail_batch
 
 
 def extract_somalier(

--- a/src/lrs_annotation/jobs/snps_indels/AnnotateCohortMatrixtable.py
+++ b/src/lrs_annotation/jobs/snps_indels/AnnotateCohortMatrixtable.py
@@ -1,7 +1,8 @@
+from hailtop.batch.job import Job
+
 from cpg_utils import Path
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import get_batch
-from hailtop.batch.job import Job
 
 from lrs_annotation.scripts.snps_indels import vcf_to_annotate_cohort_mt
 

--- a/src/lrs_annotation/jobs/snps_indels/AnnotateDatasetMatrixtable.py
+++ b/src/lrs_annotation/jobs/snps_indels/AnnotateDatasetMatrixtable.py
@@ -1,9 +1,11 @@
+from loguru import logger
+
+from hailtop.batch.job import Job
+
 from cpg_flow.utils import can_reuse
 from cpg_utils import Path
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import get_batch
-from hailtop.batch.job import Job
-from loguru import logger
 
 from lrs_annotation.scripts import subset_mt_to_sgs
 from lrs_annotation.scripts.snps_indels import annotate_dataset_mt

--- a/src/lrs_annotation/jobs/snps_indels/AnnotateWithVep.py
+++ b/src/lrs_annotation/jobs/snps_indels/AnnotateWithVep.py
@@ -2,10 +2,11 @@ from textwrap import dedent
 from typing import Literal
 
 import hailtop.batch as hb
+from hailtop.batch.job import Job
+
 from cpg_flow.utils import can_reuse, dependency_handler
 from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve, reference_path
-from hailtop.batch.job import Job
 
 from lrs_annotation.jobs.snps_indels.GatherVcfs import gather_vcfs
 from lrs_annotation.scripts.snps_indels import vep_json_to_ht

--- a/src/lrs_annotation/jobs/snps_indels/GatherVcfs.py
+++ b/src/lrs_annotation/jobs/snps_indels/GatherVcfs.py
@@ -1,10 +1,11 @@
 import hailtop.batch as hb
+from hailtop.batch.job import Job
+
 from cpg_flow.resources import STANDARD, storage_for_joint_vcf
 from cpg_flow.utils import can_reuse
 from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import command
-from hailtop.batch.job import Job
 
 
 def gather_vcfs(

--- a/src/lrs_annotation/jobs/snps_indels/ModifyVcfJobs.py
+++ b/src/lrs_annotation/jobs/snps_indels/ModifyVcfJobs.py
@@ -28,7 +28,7 @@ def bcftools_reformat(
     local_id_mapping = batch_instance.read_input(lrs_sg_id_mapping_path)
 
     # Required file for normalisation
-    ref_fasta = config_retrieve(['workflow', 'ref_fasta'])
+    ref_fasta = config_retrieve(['references', 'ref_fasta'])
     fasta = batch_instance.read_input_group(**{'fa': ref_fasta, 'fa.fai': f'{ref_fasta}.fai'})['fa']
 
     # Use BCFtools to reheader the VCF, replacing the LRS IDs with the SG IDs

--- a/src/lrs_annotation/jobs/snps_indels/ModifyVcfJobs.py
+++ b/src/lrs_annotation/jobs/snps_indels/ModifyVcfJobs.py
@@ -1,6 +1,7 @@
+from hailtop.batch.job import Job
+
 from cpg_utils import Path, hail_batch
 from cpg_utils.config import config_retrieve
-from hailtop.batch.job import Job
 
 from lrs_annotation.utils import get_resource_overrides_for_job
 

--- a/src/lrs_annotation/jobs/snps_indels/PicardIntervals.py
+++ b/src/lrs_annotation/jobs/snps_indels/PicardIntervals.py
@@ -1,8 +1,9 @@
 import hailtop.batch as hb
+from hailtop.batch.job import Job
+
 from cpg_utils import Path
 from cpg_utils.config import config_retrieve, reference_path
 from cpg_utils.hail_batch import command
-from hailtop.batch.job import Job
 
 
 def get_intervals(

--- a/src/lrs_annotation/jobs/snps_indels/SplitVcfForVep.py
+++ b/src/lrs_annotation/jobs/snps_indels/SplitVcfForVep.py
@@ -1,10 +1,11 @@
 import hailtop.batch as hb
+from hailtop.batch.job import Job
+
 from cpg_flow.resources import HIGHMEM, STANDARD
 from cpg_flow.utils import can_reuse, dependency_handler
 from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import command
-from hailtop.batch.job import Job
 
 from lrs_annotation.utils import get_intervals_from_bed, get_resource_overrides_for_job
 

--- a/src/lrs_annotation/jobs/snps_indels/VcfToUnannotatedMt.py
+++ b/src/lrs_annotation/jobs/snps_indels/VcfToUnannotatedMt.py
@@ -1,7 +1,8 @@
+from hailtop.batch.job import Job
+
 from cpg_utils import Path
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import get_batch
-from hailtop.batch.job import Job
 
 from lrs_annotation.scripts.snps_indels import vcf_to_unannotated_mt
 

--- a/src/lrs_annotation/jobs/svs/AnnotateCohortMatrixtable.py
+++ b/src/lrs_annotation/jobs/svs/AnnotateCohortMatrixtable.py
@@ -1,7 +1,8 @@
+from hailtop.batch.job import Job
+
 from cpg_utils import Path
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import get_batch
-from hailtop.batch.job import Job
 
 from lrs_annotation.scripts.svs import vcf_to_annotate_cohort_mt
 

--- a/src/lrs_annotation/jobs/svs/AnnotateDatasetMatrixtable.py
+++ b/src/lrs_annotation/jobs/svs/AnnotateDatasetMatrixtable.py
@@ -1,8 +1,9 @@
+from hailtop.batch.job import Job
+
 from cpg_flow.utils import dependency_handler
 from cpg_utils import Path
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import get_batch
-from hailtop.batch.job import Job
 
 from lrs_annotation.scripts import subset_mt_to_sgs
 from lrs_annotation.scripts.svs import annotate_dataset_mt

--- a/src/lrs_annotation/jobs/svs/AnnotateVcfGatk.py
+++ b/src/lrs_annotation/jobs/svs/AnnotateVcfGatk.py
@@ -1,8 +1,9 @@
 from typing import Any
 
+from hailtop.batch.job import Job
+
 from cpg_utils import Path
 from cpg_utils.config import config_retrieve
-from hailtop.batch.job import Job
 
 from lrs_annotation.utils import add_gatk_sv_jobs, get_images, get_references
 

--- a/src/lrs_annotation/jobs/svs/AnnotateVcfSTRVCTVRE.py
+++ b/src/lrs_annotation/jobs/svs/AnnotateVcfSTRVCTVRE.py
@@ -1,8 +1,9 @@
 import hailtop.batch as hb
+from hailtop.batch.job import Job
+
 from cpg_utils import Path
 from cpg_utils.config import config_retrieve, image_path
 from cpg_utils.hail_batch import get_batch
-from hailtop.batch.job import Job
 
 from lrs_annotation.utils import get_references
 

--- a/src/lrs_annotation/jobs/svs/ModifySvVcf.py
+++ b/src/lrs_annotation/jobs/svs/ModifySvVcf.py
@@ -1,7 +1,8 @@
+from hailtop.batch.job import Job
+
 from cpg_utils import Path
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import get_batch
-from hailtop.batch.job import Job
 
 from lrs_annotation.scripts.svs import sv_vcf_modifier
 

--- a/src/lrs_annotation/scripts/mt_to_es.py
+++ b/src/lrs_annotation/scripts/mt_to_es.py
@@ -11,11 +11,13 @@ from argparse import ArgumentParser
 from io import StringIO
 
 import elasticsearch
+from loguru import logger
+
 import hail as hl
+
 from cpg_utils import to_path
 from cpg_utils.cloud import read_secret
 from cpg_utils.config import config_retrieve
-from loguru import logger
 
 # CONSTANTS stolen from https://github.com/broadinstitute/seqr-loading-pipelines/blob/c113106204165e22b7a8c629054e94533615e7d2/hail_scripts/elasticsearch/elasticsearch_utils.py#L13
 # make encoded values as human-readable as possible

--- a/src/lrs_annotation/scripts/reregister_pacbio_analyses.py
+++ b/src/lrs_annotation/scripts/reregister_pacbio_analyses.py
@@ -1,7 +1,8 @@
 import argparse
 
-from cpg_utils import to_path
 from loguru import logger
+
+from cpg_utils import to_path
 from metamist.apis import AnalysisApi
 from metamist.graphql import gql, query
 from metamist.models import Analysis, AnalysisStatus, AnalysisUpdateModel

--- a/src/lrs_annotation/scripts/snps_indels/annotate_dataset_mt.py
+++ b/src/lrs_annotation/scripts/snps_indels/annotate_dataset_mt.py
@@ -1,8 +1,10 @@
 from argparse import ArgumentParser
 
-import hail as hl
-from cpg_utils.hail_batch import init_batch
 from loguru import logger
+
+import hail as hl
+
+from cpg_utils.hail_batch import init_batch
 
 from lrs_annotation.utils import get_init_batch_args_for_job
 

--- a/src/lrs_annotation/scripts/snps_indels/vcf_to_annotate_cohort_mt.py
+++ b/src/lrs_annotation/scripts/snps_indels/vcf_to_annotate_cohort_mt.py
@@ -4,11 +4,13 @@ Hail Query functions for seqr loader.
 
 from argparse import ArgumentParser
 
+from loguru import logger
+
 import hail as hl
+
 from cpg_flow.utils import checkpoint_hail
 from cpg_utils.config import config_retrieve, reference_path
 from cpg_utils.hail_batch import genome_build, init_batch
-from loguru import logger
 
 from lrs_annotation.hail_scripts.computed_fields import variant_id, vep
 from lrs_annotation.utils import get_init_batch_args_for_job

--- a/src/lrs_annotation/scripts/snps_indels/vcf_to_unannotated_mt.py
+++ b/src/lrs_annotation/scripts/snps_indels/vcf_to_unannotated_mt.py
@@ -1,8 +1,10 @@
 from argparse import ArgumentParser
 
-import hail as hl
-from cpg_utils.hail_batch import genome_build, init_batch
 from loguru import logger
+
+import hail as hl
+
+from cpg_utils.hail_batch import genome_build, init_batch
 
 from lrs_annotation.utils import get_init_batch_args_for_job
 

--- a/src/lrs_annotation/scripts/snps_indels/vep_json_to_ht.py
+++ b/src/lrs_annotation/scripts/snps_indels/vep_json_to_ht.py
@@ -24,6 +24,7 @@ avoid relying on them downstream
 from argparse import ArgumentParser
 
 import hail as hl
+
 from cpg_utils.hail_batch import init_batch
 
 from lrs_annotation.utils import get_init_batch_args_for_job

--- a/src/lrs_annotation/scripts/subset_mt_to_sgs.py
+++ b/src/lrs_annotation/scripts/subset_mt_to_sgs.py
@@ -1,8 +1,10 @@
 from argparse import ArgumentParser
 
-import hail as hl
-from cpg_utils.hail_batch import init_batch
 from loguru import logger
+
+import hail as hl
+
+from cpg_utils.hail_batch import init_batch
 
 from lrs_annotation.utils import get_init_batch_args_for_job
 

--- a/src/lrs_annotation/scripts/svs/annotate_dataset_mt.py
+++ b/src/lrs_annotation/scripts/svs/annotate_dataset_mt.py
@@ -1,8 +1,10 @@
 from argparse import ArgumentParser
 
-import hail as hl
-from cpg_utils.hail_batch import init_batch
 from loguru import logger
+
+import hail as hl
+
+from cpg_utils.hail_batch import init_batch
 
 from lrs_annotation.utils import get_init_batch_args_for_job
 

--- a/src/lrs_annotation/scripts/svs/vcf_to_annotate_cohort_mt.py
+++ b/src/lrs_annotation/scripts/svs/vcf_to_annotate_cohort_mt.py
@@ -7,10 +7,12 @@ from argparse import ArgumentParser
 from itertools import chain, islice
 from os.path import join
 
+from loguru import logger
+
 import hail as hl
+
 from cpg_utils.config import config_retrieve, reference_path
 from cpg_utils.hail_batch import genome_build, init_batch
-from loguru import logger
 
 from lrs_annotation.utils import get_init_batch_args_for_job
 

--- a/src/lrs_annotation/snps_indels_annotation.toml
+++ b/src/lrs_annotation/snps_indels_annotation.toml
@@ -37,3 +37,6 @@ storage_gib = '50Gi'
 [workflow.resource_overrides.export_mt_to_elastic]
 cpu_cores = 4
 memory = 'lowmem'
+
+[images]
+bcftools = 'australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools:1.23.1'

--- a/src/lrs_annotation/snps_indels_annotation.toml
+++ b/src/lrs_annotation/snps_indels_annotation.toml
@@ -1,5 +1,9 @@
 [workflow]
-name = 'snps_indels_annotation'
+
+gatk_sv_commit = '890582922bccb4b651275506a34311c949417f6c'
+
+[references]
+ref_fasta = 'gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
 
 [workflow.query_filters]
 # sequencing_types = [ 'genome', 'adaptive_sampling', ]

--- a/src/lrs_annotation/snps_indels_annotation.toml
+++ b/src/lrs_annotation/snps_indels_annotation.toml
@@ -39,4 +39,4 @@ cpu_cores = 4
 memory = 'lowmem'
 
 [images]
-bcftools = 'australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools:1.23.1-1'
+bcftools = 'australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools:1.24-1'

--- a/src/lrs_annotation/snps_indels_annotation.toml
+++ b/src/lrs_annotation/snps_indels_annotation.toml
@@ -39,4 +39,4 @@ cpu_cores = 4
 memory = 'lowmem'
 
 [images]
-bcftools = 'australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools:1.23.1'
+bcftools = 'australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools:1.23.1-1'

--- a/src/lrs_annotation/snps_indels_annotation_stages.py
+++ b/src/lrs_annotation/snps_indels_annotation_stages.py
@@ -2,16 +2,17 @@
 Workflow for annotating long-read SNPs and Indels data into a seqr-ready format.
 """
 
+from google.api_core.exceptions import PermissionDenied
+from loguru import logger
+
 from cpg_flow import stage, targets, workflow
 from cpg_flow.utils import tshirt_mt_sizing
 from cpg_flow.workflow import get_multicohort
 from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import get_batch
-from google.api_core.exceptions import PermissionDenied
-from inputs import get_sgs_from_datasets, query_for_lrs_mappings, query_for_lrs_vcfs
-from loguru import logger
 
+from lrs_annotation.inputs import get_sgs_from_datasets, query_for_lrs_mappings, query_for_lrs_vcfs
 from lrs_annotation.jobs.ExportMtToElasticsearch import export_mt_to_elasticsearch
 from lrs_annotation.jobs.snps_indels import (
     AnnotateCohortMatrixtable,
@@ -77,19 +78,19 @@ class ModifyVcf(stage.SequencingGroupStage):
             'index': sgid_prefix / f'{sequencing_group.id}_reformatted.vcf.gz.tbi',
         }
 
-    def queue_jobs(self, sg: targets.SequencingGroup, inputs: stage.StageInput) -> stage.StageOutput:
+    def queue_jobs(self, sg: targets.SequencingGroup, inputs: stage.StageInput) -> stage.StageOutput | None:
         """
         - Use bcftools job to reheader the VCF with the replacement sample IDs, normalise it, and then sort
         - Then block-gzip and index it
         - This is explicitly skipped for the parents in trio joint-called VCFs
         """
         multicohort_datasets = [ds.name for ds in get_multicohort().get_datasets()]
-        sg_ids = []
-        sg_vcfs = {}
+        sg_ids: list[str] = []
+        sg_vcfs: dict[str, dict] = {}
         for ds in multicohort_datasets:
-            sgs = query_for_lrs_vcfs(dataset_name=ds)
-            sg_ids.extend(sgs['sg_ids'])
-            sg_vcfs.update(sgs['vcfs'])
+            query_sg_ids, query_vcfs = query_for_lrs_vcfs(dataset_name=ds)
+            sg_ids.extend(query_sg_ids)
+            sg_vcfs.update(query_vcfs)
 
         assert not set(get_multicohort().get_sequencing_group_ids()) - set(sg_ids), (
             'SGs in the multicohort do not have VCFs matching the filter criteria: '
@@ -135,11 +136,10 @@ class MergeVcfsWithBcftools(stage.MultiCohortStage):
         """
         Use bcftools to merge all the VCFs, and then fill in the tags (requires bcftools 1.18+)
         """
-        sgs = get_sgs_from_datasets([d.name for d in multicohort.get_datasets()])
+        _, sgs = get_sgs_from_datasets([d.name for d in multicohort.get_datasets()])
 
         # Get the reformatted VCFs from the previous stage
-        reformatted_vcfs = inputs.as_dict_by_target(ModifyVcf)
-        reformatted_vcfs = {sg_id: vcf for sg_id, vcf in reformatted_vcfs.items() if sg_id in sgs['vcfs']}
+        reformatted_vcfs = {sg_id: vcf for sg_id, vcf in inputs.as_dict_by_target(ModifyVcf).items() if sg_id in sgs}
 
         if len(reformatted_vcfs) == 1:
             logger.info('Only one VCF found, skipping merge')
@@ -461,9 +461,10 @@ class ExportSnpsIndelsMtToESIndex(stage.DatasetStage):
         # and just the name, used after localisation
         mt_name = mt_path.split('/')[-1]
 
+        sg_ids, _ = get_sgs_from_datasets([dataset.name])
         req_storage = tshirt_mt_sizing(
             sequencing_type=config_retrieve(['workflow', 'sequencing_type']),
-            cohort_size=len(get_sgs_from_datasets([dataset.name])),
+            cohort_size=len(sg_ids),
         )
         # set all job attributes in one bash
         job = export_mt_to_elasticsearch(

--- a/src/lrs_annotation/snps_indels_annotation_stages.py
+++ b/src/lrs_annotation/snps_indels_annotation_stages.py
@@ -54,8 +54,8 @@ class WriteLrsIdToSgIdMappingFile(stage.MultiCohortStage):
 
         lrs_mapping = query_for_lrs_mappings(
             dataset_names=get_dataset_names([d.name for d in multicohort.get_datasets()]),
-            sequencing_types=get_query_filter_from_config('sequencing_types', make_tuple=False),
-            sequencing_platforms=get_query_filter_from_config('sequencing_platforms', make_tuple=False),
+            sequencing_types=get_query_filter_from_config('sequencing_types', make_tuple=False),  # type: ignore[arg-type]
+            sequencing_platforms=get_query_filter_from_config('sequencing_platforms', make_tuple=False),  # type: ignore[arg-type]
         )
         lrs_sg_id_mapping = {lrs_id: mapping['sg_id'] for lrs_id, mapping in lrs_mapping.items()}
 

--- a/src/lrs_annotation/svs_annotation_stages.py
+++ b/src/lrs_annotation/svs_annotation_stages.py
@@ -2,14 +2,7 @@
 Workflow for annotating long-read SVs data into a seqr-ready format.
 """
 
-from cpg_flow import stage, targets, workflow
-from cpg_flow.utils import tshirt_mt_sizing
-from cpg_flow.workflow import get_multicohort
-from cpg_utils import Path, to_path
-from cpg_utils.config import AR_GUID_NAME, config_retrieve, try_get_ar_guid
-from cpg_utils.hail_batch import get_batch
 from google.api_core.exceptions import PermissionDenied
-from inputs import get_sgs_from_datasets, query_for_lrs_mappings, query_for_lrs_vcfs
 from loguru import logger
 from utils import (
     es_password,
@@ -19,6 +12,14 @@ from utils import (
     write_mapping_to_file,
 )
 
+from cpg_flow import stage, targets, workflow
+from cpg_flow.utils import tshirt_mt_sizing
+from cpg_flow.workflow import get_multicohort
+from cpg_utils import Path, to_path
+from cpg_utils.config import AR_GUID_NAME, config_retrieve, try_get_ar_guid
+from cpg_utils.hail_batch import get_batch
+
+from lrs_annotation.inputs import get_sgs_from_datasets, query_for_lrs_mappings, query_for_lrs_vcfs
 from lrs_annotation.jobs.ExportMtToElasticsearch import export_mt_to_elasticsearch
 from lrs_annotation.jobs.svs import (
     AnnotateCohortMatrixtable,
@@ -113,12 +114,12 @@ class ModifySVsVcf(stage.SequencingGroupStage):
         - Adds a unique ID to each record for compatibility with GATK SV sorting
         """
         multicohort_datasets = [ds.name for ds in get_multicohort().get_datasets()]
-        sg_ids = []
-        sg_vcfs = {}
+        sg_ids: list[str] = []
+        sg_vcfs: dict[str, dict] = {}
         for ds in multicohort_datasets:
-            sgs = query_for_lrs_vcfs(dataset_name=ds)
-            sg_ids.extend(sgs['sg_ids'])
-            sg_vcfs.update(sgs['vcfs'])
+            query_sgids, query_vcfs = query_for_lrs_vcfs(dataset_name=ds)
+            sg_ids.extend(query_sgids)
+            sg_vcfs.update(query_vcfs)
 
         assert not set(get_multicohort().get_sequencing_group_ids()) - set(sg_ids), (
             'SGs in the multicohort do not have VCFs matching the filter criteria: '
@@ -169,7 +170,7 @@ class ReformatSVsVcfWithBcftools(stage.SequencingGroupStage):
         - Use bcftools job to reheader the VCF with the replacement sample IDs, normalise it, and then sort
         - Then block-gzip and index it
         """
-        sg_vcfs = query_for_lrs_vcfs(dataset_name=get_dataset_name(sg.dataset.name))['vcfs']
+        _, sg_vcfs = query_for_lrs_vcfs(dataset_name=get_dataset_name(sg.dataset.name))
         if sg.id not in sg_vcfs:
             return None
 
@@ -207,10 +208,11 @@ class MergeSVsVcfsWithBcftools(stage.MultiCohortStage):
         """
         Use bcftools to merge all the VCFs, and then fill in the tags (requires bcftools 1.18+)
         """
-        sgs = get_sgs_from_datasets([d.name for d in multicohort.get_datasets()])
+        _, sgs = get_sgs_from_datasets([d.name for d in multicohort.get_datasets()])
         # Get the reformatted VCFs from the previous stage
-        reformatted_vcfs = inputs.as_dict_by_target(ReformatSVsVcfWithBcftools)
-        reformatted_vcfs = {sg_id: vcf for sg_id, vcf in reformatted_vcfs.items() if sg_id in sgs['vcfs']}
+        reformatted_vcfs = {
+            sg_id: vcf for sg_id, vcf in inputs.as_dict_by_target(ReformatSVsVcfWithBcftools).items() if sg_id in sgs
+        }
 
         if len(reformatted_vcfs) == 1:
             logger.info('Only one VCF found, skipping merge')

--- a/src/lrs_annotation/utils.py
+++ b/src/lrs_annotation/utils.py
@@ -9,14 +9,15 @@ from os.path import join
 from random import randint
 from typing import Any
 
+from hailtop.batch.job import BashJob, Job
+
 from cpg_flow import targets
 from cpg_flow.utils import logger
 from cpg_utils import Path
 from cpg_utils.cloud import read_secret
-from cpg_utils.config import ConfigError, config_retrieve, image_path, reference_path
+from cpg_utils.config import ConfigError, config_retrieve, dataset_for_access_level, image_path, reference_path
 from cpg_utils.cromwell import CromwellOutputType, run_cromwell_workflow_from_repo_and_get_outputs
 from cpg_utils.hail_batch import command, get_batch
-from hailtop.batch.job import BashJob, Job
 
 GATK_SV_COMMIT = config_retrieve(['workflow', 'gatk_sv_commit'])
 
@@ -31,19 +32,11 @@ class CromwellJobSizes(Enum):
     LARGE = 'large'
 
 
-def get_dataset_name(dataset: str) -> str:
-    """
-    Add -test suffix to dataset name if in test mode.
-    """
-    test = config_retrieve(['workflow', 'access_level']) == 'test'
-    return dataset + '-test' if test else dataset
-
-
 def get_dataset_names(datasets: str | list[str]) -> list[str]:
     """
     Add -test suffix to dataset names if in test mode.
     """
-    return [get_dataset_name(dataset) for dataset in datasets]
+    return [dataset_for_access_level(dataset) for dataset in datasets]
 
 
 def get_query_filter_from_config(field_name: str, make_tuple=True) -> tuple[str] | list[str] | None:

--- a/src/lrs_annotation/utils.py
+++ b/src/lrs_annotation/utils.py
@@ -19,7 +19,7 @@ from cpg_utils.config import ConfigError, config_retrieve, dataset_for_access_le
 from cpg_utils.cromwell import CromwellOutputType, run_cromwell_workflow_from_repo_and_get_outputs
 from cpg_utils.hail_batch import command, get_batch
 
-GATK_SV_COMMIT = config_retrieve(['workflow', 'gatk_sv_commit'])
+GATK_SV_COMMIT = config_retrieve(['workflow', 'gatk_sv_commit'], '890582922bccb4b651275506a34311c949417f6c')
 
 
 class CromwellJobSizes(Enum):


### PR DESCRIPTION
# Purpose

  - Import error: https://batch.hail.populationgenomics.org.au/batches/1134383/jobs/1
    - this can be overcome by referencing the run_workflow script as a full path

## Proposed Changes

  - Main change - changes `from inputs import get_sgs...` to `from lrs_annotation.inputs import get_sgs...`
  - Secondary changes - alters the return type of `query_for_lrs_vcfs` and `get_sgs_from_datasets` from a `dict[str, dict | list[str]]` to `tuple[list[str], dict]`. By returning both elements specifically, it avoids the linter flagging a whole bunch of operations on the list which aren't valid on the dict etc. 
  - Tertiary change - the isort block in pyproject.toml was missing a few lines. Specifically the lines identifying CPG and Hail-associated packages, so that the import ordering would be consistent with other repos. Unfortunately this has generated the majority of changes...
  - Quaternary change - depends on the latest version of CPG-utils from [here](https://github.com/populationgenomics/cpg-utils/pull/198), meaning the `dataset -> dataset-test` string conversion method can be deleted and imported instead.
  - Other change - adds a configuration default value for GATK-SV commit to use

All in all this ended up being a ton of changes, for what could have been a simple import change (Main change, the rest is cosmetic/linting)

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
