### PR TITLE
Fix dataset name bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.17
+ENV VERSION=0.2.18
 
 WORKDIR /cpg_flow_lrs_annotation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPG-Flow - Long Read Sequencing Annotation for seqr
 
-Version 0.2.17
+Version 0.2.18
 
 A CPG workflow for creating annotated callsets from long read data, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.2.17"
+version="0.2.18"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -103,7 +103,7 @@ hail = ["hail", "hailtop"]
 "src/lrs_annotation/bam_to_cram_stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.2.17"
+current_version = "0.2.18"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/lrs_annotation/inputs.py
+++ b/src/lrs_annotation/inputs.py
@@ -122,8 +122,10 @@ def query_for_lrs_vcfs(dataset_name: str) -> tuple[list[str], dict[str, dict]]:
         Note: Not every SG will have a VCF, since some may be parents in joint-called families.
         These SGs will still be included in the 'sg_ids' list, but their VCFs will not be present in the 'vcfs' dict.
     """
-    if config_retrieve(['workflow', 'access_level']) == 'test' and not dataset_name.endswith('-test'):
-        dataset_name += '-test'
+
+    # adjust with a -test suffix if appropriate
+    dataset_name = dataset_for_access_level(dataset_name)
+
     query_filters: dict = config_retrieve(['workflow', 'query_filters'], default={})
     if not query_filters:
         raise ValueError('No query filters found in the config file. Please check your configuration.')

--- a/src/lrs_annotation/svs_annotation_stages.py
+++ b/src/lrs_annotation/svs_annotation_stages.py
@@ -6,7 +6,6 @@ from google.api_core.exceptions import PermissionDenied
 from loguru import logger
 from utils import (
     es_password,
-    get_dataset_name,
     get_dataset_names,
     get_query_filter_from_config,
     write_mapping_to_file,
@@ -170,7 +169,7 @@ class ReformatSVsVcfWithBcftools(stage.SequencingGroupStage):
         - Use bcftools job to reheader the VCF with the replacement sample IDs, normalise it, and then sort
         - Then block-gzip and index it
         """
-        _, sg_vcfs = query_for_lrs_vcfs(dataset_name=get_dataset_name(sg.dataset.name))
+        _, sg_vcfs = query_for_lrs_vcfs(dataset_name=sg.dataset.name)
         if sg.id not in sg_vcfs:
             return None
 


### PR DESCRIPTION
# Purpose

  - Previous PR removed a method to situationally suffix `dataset` with `-test` substring
  - static inspection didn't catch that the removed method had an additional usage, which would break future SV workflows

## Proposed Changes

  - Removes the broken import, and uses the cpg-utils method
