### PR TITLE
Write more to analysis meta

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.3.1
+ENV VERSION=0.3.2
 
 WORKDIR /cpg_flow_lrs_annotation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPG-Flow - Long Read Sequencing Annotation for seqr
 
-Version 0.3.1
+Version 0.3.2
 
 A CPG workflow for creating annotated callsets from long read data, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.3.1"
+version="0.3.2"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -103,7 +103,7 @@ hail = ["hail", "hailtop"]
 "src/lrs_annotation/bam_to_cram_stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.3.1"
+current_version = "0.3.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/lrs_annotation/scripts/mt_to_es.py
+++ b/src/lrs_annotation/scripts/mt_to_es.py
@@ -323,8 +323,10 @@ def main():
     seqr_dataset_type = config_retrieve(['workflow', 'seqr_dataset_type'], 'SNV_INDEL')
     meta = {
         'stage': 'ExportSnpsIndelsMtToESIndex' if seqr_dataset_type == 'SNV_INDEL' else 'ExportSVsMtToElasticIndex',
+        'sequencing_type': config_retrieve(['workflow', 'sequencing_type'], 'genome'),
         'query_filters': config_retrieve(['workflow', 'query_filters'], {}),
         'seqr-dataset-type': seqr_dataset_type,
+        'input_vcfs': args.path_to_input_vcfs_file,
     }
 
     create_new(

--- a/src/lrs_annotation/scripts/snps_indels/annotate_dataset_mt.py
+++ b/src/lrs_annotation/scripts/snps_indels/annotate_dataset_mt.py
@@ -126,6 +126,7 @@ def cli_main():
 
     meta = {
         'stage': 'SubsetMtToDatasetWithHail',
+        'sequencing_type': config_retrieve(['workflow', 'sequencing_type'], 'genome'),
         'query_filters': config_retrieve(['workflow', 'query_filters'], {}),
         'seqr-dataset-type': config_retrieve(['workflow', 'seqr_dataset_type'], 'SNV_INDEL'),
     }

--- a/src/lrs_annotation/scripts/svs/annotate_dataset_mt.py
+++ b/src/lrs_annotation/scripts/svs/annotate_dataset_mt.py
@@ -104,6 +104,7 @@ def cli_main():
 
     meta = {
         'stage': 'SubsetSVsMtToDatasetWithHail',
+        'sequencing_type': config_retrieve(['workflow', 'sequencing_type'], 'genome'),
         'query_filters': config_retrieve(['workflow', 'query_filters'], {}),
         'seqr-dataset-type': config_retrieve(['workflow', 'seqr_dataset_type'], 'SV'),
     }


### PR DESCRIPTION
# Purpose

  - Analysis meta was missing the expected `sequencing_type` string field for the matrixtable analyses and the es-index analyses now being manually registered (see #49)
  - Also add the `input_vcfs` to the es-index meta, since this file is not properly being registered in the secondary files dict (likely a bug with analysis file registration against the `output_file` Metamist table)