### PR TITLE
Scope VCF inputs file and SGs list to only those in the multicohort

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.3.4
+ENV VERSION=0.3.5
 
 WORKDIR /cpg_flow_lrs_annotation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPG-Flow - Long Read Sequencing Annotation for seqr
 
-Version 0.3.4
+Version 0.3.5
 
 A CPG workflow for creating annotated callsets from long read data, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.3.4"
+version="0.3.5"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -103,7 +103,7 @@ hail = ["hail", "hailtop"]
 "src/lrs_annotation/bam_to_cram_stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.3.4"
+current_version = "0.3.5"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/lrs_annotation/snps_indels_annotation_stages.py
+++ b/src/lrs_annotation/snps_indels_annotation_stages.py
@@ -412,6 +412,7 @@ class SubsetMtToDatasetWithHail(stage.DatasetStage):
             sg_ids = family_sgs['family_sg_ids']
         else:
             sg_ids, _ = get_sgs_from_datasets([dataset.name])
+        sg_ids = [sg_id for sg_id in sg_ids if sg_id in get_multicohort().get_sequencing_group_ids()]
 
         mt_path = inputs.as_path(target=get_multicohort(), stage=AnnotateCohortMtFromVcfWithHail, key='mt')
 
@@ -488,6 +489,7 @@ class ExportSnpsIndelsMtToESIndex(stage.DatasetStage):
             sg_ids = family_sgs['family_sg_ids']
         else:
             sg_ids, _ = get_sgs_from_datasets([dataset.name])
+        sg_ids = [sg_id for sg_id in sg_ids if sg_id in get_multicohort().get_sequencing_group_ids()]
 
         # set all job attributes in one bash
         job = export_mt_to_elasticsearch(

--- a/src/lrs_annotation/snps_indels_annotation_stages.py
+++ b/src/lrs_annotation/snps_indels_annotation_stages.py
@@ -136,7 +136,7 @@ class ModifyVcf(stage.SequencingGroupStage):
                     'meta': sg_vcfs[sg_id]['meta'],
                 }
                 for sg_id in sg_ids
-                if sg_id in sg_vcfs
+                if sg_id in sg_vcfs and sg_id in get_multicohort().get_sequencing_group_ids()
             }
             write_to_json(sg_vcfs_to_write, sg_vcfs_file)
 

--- a/src/lrs_annotation/svs_annotation_stages.py
+++ b/src/lrs_annotation/svs_annotation_stages.py
@@ -167,7 +167,7 @@ class ModifySVsVcf(stage.SequencingGroupStage):
                     'meta': sg_vcfs[sg_id]['meta'],
                 }
                 for sg_id in sg_ids
-                if sg_id in sg_vcfs
+                if sg_id in sg_vcfs and sg_id in get_multicohort().get_sequencing_group_ids()
             }
             write_to_json(sg_vcfs_to_write, sg_vcfs_file)
 

--- a/src/lrs_annotation/svs_annotation_stages.py
+++ b/src/lrs_annotation/svs_annotation_stages.py
@@ -392,6 +392,7 @@ class SubsetSVsMtToDatasetWithHail(stage.DatasetStage):
         checkpoint_prefix = dataset.tmp_prefix() / sg_hash / 'svs' / 'mt' / 'checkpoints'
 
         sg_ids, _ = get_sgs_from_datasets([dataset.name])
+        sg_ids = [sg_id for sg_id in sg_ids if sg_id in get_multicohort().get_sequencing_group_ids()]
 
         jobs = AnnotateDatasetMatrixtable.annotate_dataset_jobs_sv(
             dataset=dataset_for_access_level(dataset.name),
@@ -456,6 +457,7 @@ class ExportSVsMtToElasticIndex(stage.DatasetStage):
         done_flag = str(outputs['done_flag'])
 
         sg_ids, _ = get_sgs_from_datasets([dataset.name])
+        sg_ids = [sg_id for sg_id in sg_ids if sg_id in get_multicohort().get_sequencing_group_ids()]
 
         job = export_mt_to_elasticsearch(
             batch=get_batch(),


### PR DESCRIPTION
# Purpose

  - The input VCFs file and SGs list is collected from a Metamist query that finds all SGs with a VCF matching the query filters. This had the possibility of collecting SGs beyond the input cohorts, leading to errors where mt subsets would be attempted for SGs that were absent from the callset. This PR adds a few lines to filter down the SGs list to only those in the multicohort. e.g. https://batch.hail.populationgenomics.org.au/batches/1135215/jobs/991

## Proposed Changes

  - Filter `sg_vcfs` and `sg_ids` to only those IDs in the `get_multicohort().get_sequencing_group_ids()` list
