### PR TITLE
Fix reformatted vcf path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.3.6
+ENV VERSION=0.3.7
 
 WORKDIR /cpg_flow_lrs_annotation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPG-Flow - Long Read Sequencing Annotation for seqr
 
-Version 0.3.6
+Version 0.3.7
 
 A CPG workflow for creating annotated callsets from long read data, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='A pipeline for creating annotated callsets containing SNPs and inde
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.3.6"
+version="0.3.7"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -103,7 +103,7 @@ hail = ["hail", "hailtop"]
 "src/lrs_annotation/bam_to_cram_stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.3.6"
+current_version = "0.3.7"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/lrs_annotation/snps_indels_annotation_stages.py
+++ b/src/lrs_annotation/snps_indels_annotation_stages.py
@@ -130,13 +130,13 @@ class ModifyVcf(stage.SequencingGroupStage):
         if not sg_vcfs_file.exists():
             logger.info(f'Writing input VCFs to {sg_vcfs_file}')
             sg_vcfs_to_write = {
-                sg_id: {
-                    'original_vcf': str(sg_vcfs[sg_id]['vcf']),
-                    'reformatted_vcf': str(outputs['vcf']),
-                    'meta': sg_vcfs[sg_id]['meta'],
+                sg.id: {
+                    'original_vcf': str(sg_vcfs[sg.id]['vcf']),
+                    'reformatted_vcf': str(self.expected_outputs(sg)['vcf']),
+                    'meta': sg_vcfs[sg.id]['meta'],
                 }
-                for sg_id in sg_ids
-                if sg_id in sg_vcfs and sg_id in get_multicohort().get_sequencing_group_ids()
+                for sg in get_multicohort().get_sequencing_groups()
+                if sg.id in sg_vcfs
             }
             write_to_json(sg_vcfs_to_write, sg_vcfs_file)
 

--- a/src/lrs_annotation/svs_annotation_stages.py
+++ b/src/lrs_annotation/svs_annotation_stages.py
@@ -161,13 +161,13 @@ class ModifySVsVcf(stage.SequencingGroupStage):
         if not sg_vcfs_file.exists():
             logger.info(f'Writing input VCFs to {sg_vcfs_file}')
             sg_vcfs_to_write = {
-                sg_id: {
-                    'original_vcf': str(sg_vcfs[sg_id]['vcf']),
-                    'reformatted_vcf': str(expected_outputs['vcf']),
-                    'meta': sg_vcfs[sg_id]['meta'],
+                sg.id: {
+                    'original_vcf': str(sg_vcfs[sg.id]['vcf']),
+                    'reformatted_vcf': str(self.expected_outputs(sg)['vcf']),
+                    'meta': sg_vcfs[sg.id]['meta'],
                 }
-                for sg_id in sg_ids
-                if sg_id in sg_vcfs and sg_id in get_multicohort().get_sequencing_group_ids()
+                for sg in get_multicohort().get_sequencing_groups()
+                if sg.id in sg_vcfs
             }
             write_to_json(sg_vcfs_to_write, sg_vcfs_file)
 


### PR DESCRIPTION
# Purpose

  - The written input VCFs file has a bug that meant all `"reformatted_vcf"` entries were the same path, because it was reusing the `outputs` from the current `SequencingGroup`'s expected outputs. This PR changes the logic to generate the reformatted VCF path dynamically using the `SequencingGroup` objects from the multicohort.
    - It's not totally disastrous, the reformatted VCFs only exist for 7 days in temp storage anyway, the original VCF path is far more informative. But this fix is still important for overall correctness.

## Proposed Changes

  - Fix `for` loop used to build input VCFs file

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
